### PR TITLE
feat: round store and live dashboard round state

### DIFF
--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -36,3 +36,16 @@ export const educationApi = {
     getGuides: () => fetchApi<Guide[]>('/api/education/guides'),
     getTip: () => fetchApi<Tip | null>('/api/education/tip'),
 };
+
+export interface Round {
+    id: string | number;
+    status?: string;
+    startsAt?: string;
+    endsAt?: string;
+    resolvedAt?: string;
+    [key: string]: unknown;
+}
+
+export const roundsApi = {
+    getActive: () => fetchApi<Round | null>('/api/rounds/active'),
+};

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,13 +1,28 @@
+import { useEffect } from "react";
 import { ChatSidebar } from "../components/ChatSidebar";
 import PriceChart from "../components/PriceChart";
 import PredictionCard from "../components/PredictionCard";
 import type { PredictionData } from "../components/PredictionControls";
+import { useRoundStore } from "../store/useRoundStore";
 
 interface DashboardProps {
   showNewsRibbon?: boolean;
 }
 
 const Dashboard = ({ showNewsRibbon = true }: DashboardProps) => {
+  const isRoundActive = useRoundStore((state) => state.isRoundActive);
+
+  useEffect(() => {
+    const { fetchActiveRound, subscribeToRoundEvents } = useRoundStore.getState();
+
+    void fetchActiveRound();
+    const unsubscribe = subscribeToRoundEvents();
+
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
   const handlePrediction = (data: PredictionData) => {
     console.log("Prediction made:", data);
   };
@@ -22,7 +37,7 @@ const Dashboard = ({ showNewsRibbon = true }: DashboardProps) => {
           <div className="dashboard__center lg:col-span-1 flex flex-col gap-6">
             <PredictionCard
               isWalletConnected={true}
-              isRoundActive={true}
+              isRoundActive={isRoundActive}
               onPrediction={handlePrediction}
             />
           </div>

--- a/src/store/useRoundStore.ts
+++ b/src/store/useRoundStore.ts
@@ -1,0 +1,145 @@
+import { create } from 'zustand';
+import { roundsApi, type Round } from '../lib/api-client';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+
+interface RoundEventEnvelope {
+  event?: string;
+  type?: string;
+  data?: unknown;
+  payload?: unknown;
+  round?: unknown;
+}
+
+interface RoundStore {
+  activeRound: Round | null;
+  isRoundActive: boolean;
+  isLoading: boolean;
+  error: string | null;
+  fetchActiveRound: () => Promise<void>;
+  subscribeToRoundEvents: () => () => void;
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function toRound(value: unknown): Round | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const maybeRound = value as Record<string, unknown>;
+  const id = maybeRound.id;
+  if (typeof id !== 'string' && typeof id !== 'number') {
+    return null;
+  }
+
+  return maybeRound as Round;
+}
+
+function getEventRound(payload: unknown): Round | null {
+  const directRound = toRound(payload);
+  if (directRound) return directRound;
+
+  if (!payload || typeof payload !== 'object') return null;
+
+  const envelope = payload as RoundEventEnvelope;
+  return (
+    toRound(envelope.round) ??
+    toRound(envelope.data) ??
+    toRound(envelope.payload) ??
+    null
+  );
+}
+
+function getEventType(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null;
+
+  const envelope = payload as RoundEventEnvelope;
+  const eventType = envelope.event ?? envelope.type;
+  return typeof eventType === 'string' ? eventType : null;
+}
+
+export const useRoundStore = create<RoundStore>((set) => ({
+  activeRound: null,
+  isRoundActive: false,
+  isLoading: false,
+  error: null,
+
+  fetchActiveRound: async () => {
+    set({ isLoading: true, error: null });
+
+    try {
+      const activeRound = await roundsApi.getActive();
+      set({ activeRound, isRoundActive: !!activeRound, isLoading: false });
+    } catch (error) {
+      set({
+        activeRound: null,
+        isRoundActive: false,
+        isLoading: false,
+        error: error instanceof Error ? error.message : 'Failed to fetch active round',
+      });
+    }
+  },
+
+  subscribeToRoundEvents: () => {
+    const stream = new EventSource(`${API_BASE}/api/rounds/events`);
+
+    const handleRoundStarted = (payload: unknown) => {
+      const startedRound = getEventRound(payload);
+      set({
+        activeRound: startedRound,
+        isRoundActive: true,
+        error: null,
+      });
+    };
+
+    const handleRoundResolved = (payload: unknown) => {
+      const resolvedRound = getEventRound(payload);
+      set({
+        activeRound: resolvedRound,
+        isRoundActive: false,
+        error: null,
+      });
+    };
+
+    const handleNamedRoundStarted = (event: MessageEvent) => {
+      handleRoundStarted(parseJson(event.data));
+    };
+
+    const handleNamedRoundResolved = (event: MessageEvent) => {
+      handleRoundResolved(parseJson(event.data));
+    };
+
+    const handleGenericMessage = (event: MessageEvent) => {
+      const payload = parseJson(event.data);
+      const eventType = getEventType(payload);
+
+      if (eventType === 'round:started') {
+        handleRoundStarted(payload);
+      }
+
+      if (eventType === 'round:resolved') {
+        handleRoundResolved(payload);
+      }
+    };
+
+    stream.addEventListener('round:started', handleNamedRoundStarted);
+    stream.addEventListener('round:resolved', handleNamedRoundResolved);
+    stream.onmessage = handleGenericMessage;
+    stream.onerror = () => {
+      set({ error: 'Round event stream disconnected' });
+    };
+
+    return () => {
+      stream.removeEventListener('round:started', handleNamedRoundStarted);
+      stream.removeEventListener('round:resolved', handleNamedRoundResolved);
+      stream.close();
+    };
+  },
+}));


### PR DESCRIPTION
## Description
Add a live round store and wire Dashboard round state to backend data/events.

Closes #40

## Changes proposed

### What were you told to do?
I was tasked with removing hardcoded dashboard round state and syncing round activity from backend APIs/events.

Requirements included:
- Add `src/store/useRoundStore.ts`
- Fetch active round from `GET /api/rounds/active`
- Replace `isRoundActive={true}` in Dashboard with live state
- Subscribe to `round:started` and `round:resolved`

### What did I do?

#### Added a dedicated round store
Created `src/store/useRoundStore.ts` and implemented:
- `activeRound`, `isRoundActive`, `isLoading`, and `error` state
- `fetchActiveRound()` that calls `GET /api/rounds/active`
- `subscribeToRoundEvents()` that listens for `round:started` and `round:resolved`

#### Added rounds API client support
Updated `src/lib/api-client.ts` with:
- `Round` interface
- `roundsApi.getActive()` for `GET /api/rounds/active`

#### Wired Dashboard to live round state
Updated `src/pages/Dashboard.tsx` to:
- read `isRoundActive` from `useRoundStore`
- fetch active round on mount
- subscribe/unsubscribe to round events on mount/unmount
- remove hardcoded `isRoundActive={true}`

#### Validation and results
- Attempted `npm run build`
- Local environment is missing type definition packages (`vite/client`, `node`), so build validation could not complete in this workspace state

## Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] My commit messages styles matches our requested structure.
- [ ] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `npm run build` attempted locally
- Build blocked by missing local type definition packages (`vite/client`, `node`)
