### PR TITLE
feat: fetch and display user prediction history

### DIFF
--- a/src/components/PredictionHistory.tsx
+++ b/src/components/PredictionHistory.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useState } from "react";
+import { predictionsApi, type UserPrediction } from "../lib/api-client";
+
+interface PredictionHistoryProps {
+  userId: string | null;
+}
+
+function formatDate(value?: string): string {
+  if (!value) return "Unknown time";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown time";
+  return date.toLocaleString();
+}
+
+function formatStake(value?: string | number): string {
+  if (value === undefined || value === null || value === "") return "N/A";
+  if (typeof value === "number") return value.toString();
+  return value;
+}
+
+export default function PredictionHistory({ userId }: PredictionHistoryProps) {
+  const [history, setHistory] = useState<UserPrediction[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadHistory = useCallback(async () => {
+    if (!userId) {
+      setHistory([]);
+      setError(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const predictions = await predictionsApi.getUserHistory(userId);
+      setHistory(predictions);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch prediction history");
+      setHistory([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    void loadHistory();
+  }, [loadHistory]);
+
+  return (
+    <section className="bg-white dark:bg-gray-800 p-6 shadow-sm rounded-xl border border-gray-100 dark:border-gray-700">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Prediction History</h3>
+        {userId && (
+          <button
+            type="button"
+            className="text-sm font-medium text-[#2C4BFD] hover:underline"
+            onClick={() => void loadHistory()}
+          >
+            Refresh
+          </button>
+        )}
+      </div>
+
+      {!userId && (
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          Connect your wallet to view your prediction history.
+        </p>
+      )}
+
+      {isLoading && (
+        <p className="text-sm text-gray-600 dark:text-gray-300" role="status">
+          Loading prediction history...
+        </p>
+      )}
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 dark:border-red-900/40 dark:bg-red-900/20 p-3">
+          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+          <button
+            type="button"
+            className="mt-2 text-sm font-medium text-red-700 dark:text-red-300 hover:underline"
+            onClick={() => void loadHistory()}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {!isLoading && !error && userId && history.length === 0 && (
+        <p className="text-sm text-gray-600 dark:text-gray-300">No predictions yet.</p>
+      )}
+
+      {!isLoading && !error && history.length > 0 && (
+        <ul className="space-y-3">
+          {history.map((prediction, index) => {
+            const direction = typeof prediction.direction === "string" ? prediction.direction : "UNKNOWN";
+            const exactPrice =
+              prediction.exactPrice === undefined || prediction.exactPrice === null
+                ? null
+                : String(prediction.exactPrice);
+            const status = typeof prediction.status === "string" ? prediction.status : null;
+            const roundId =
+              prediction.roundId === undefined || prediction.roundId === null
+                ? null
+                : String(prediction.roundId);
+            const key =
+              `${String(prediction.id)}-${index}`;
+
+            return (
+              <li
+                key={key}
+                className="rounded-lg border border-gray-100 dark:border-gray-700 p-3 bg-gray-50 dark:bg-gray-900/30"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                    <span className={direction === "UP" ? "text-green-600" : "text-pink-600"}>{direction}</span>
+                    {" "}
+                    • Stake: {formatStake(prediction.stake)}
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    {formatDate(typeof prediction.createdAt === "string" ? prediction.createdAt : undefined)}
+                  </p>
+                </div>
+
+                <div className="mt-2 text-xs text-gray-600 dark:text-gray-300 flex flex-wrap gap-x-4 gap-y-1">
+                  {roundId && <span>Round: {roundId}</span>}
+                  {exactPrice && <span>Exact price: {exactPrice}</span>}
+                  {status && <span>Status: {status}</span>}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -49,3 +49,44 @@ export interface Round {
 export const roundsApi = {
     getActive: () => fetchApi<Round | null>('/api/rounds/active'),
 };
+
+export interface UserPrediction {
+    id: string | number;
+    direction?: string;
+    stake?: string | number;
+    exactPrice?: string | number;
+    roundId?: string | number;
+    status?: string;
+    createdAt?: string;
+    [key: string]: unknown;
+}
+
+type UserPredictionsResponse =
+    | UserPrediction[]
+    | {
+        predictions?: UserPrediction[];
+        data?: UserPrediction[];
+    };
+
+function normalizeUserPredictions(response: UserPredictionsResponse): UserPrediction[] {
+    if (Array.isArray(response)) {
+        return response;
+    }
+
+    if (Array.isArray(response.predictions)) {
+        return response.predictions;
+    }
+
+    if (Array.isArray(response.data)) {
+        return response.data;
+    }
+
+    return [];
+}
+
+export const predictionsApi = {
+    getUserHistory: async (userId: string) => {
+        const response = await fetchApi<UserPredictionsResponse>(`/api/predictions/user/${encodeURIComponent(userId)}`);
+        return normalizeUserPredictions(response);
+    },
+};

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,6 +4,8 @@ import PriceChart from "../components/PriceChart";
 import PredictionCard from "../components/PredictionCard";
 import type { PredictionData } from "../components/PredictionControls";
 import { useRoundStore } from "../store/useRoundStore";
+import PredictionHistory from "../components/PredictionHistory";
+import { useWalletStore } from "../store/useWalletStore";
 
 interface DashboardProps {
   showNewsRibbon?: boolean;
@@ -11,6 +13,7 @@ interface DashboardProps {
 
 const Dashboard = ({ showNewsRibbon = true }: DashboardProps) => {
   const isRoundActive = useRoundStore((state) => state.isRoundActive);
+  const publicKey = useWalletStore((state) => state.publicKey);
 
   useEffect(() => {
     const { fetchActiveRound, subscribeToRoundEvents } = useRoundStore.getState();
@@ -55,6 +58,8 @@ const Dashboard = ({ showNewsRibbon = true }: DashboardProps) => {
                 142 Playing Now
               </p>
             </div>
+
+            <PredictionHistory userId={publicKey} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description
Fetch and display prediction history for the logged-in user using the existing backend endpoint.

Closes #48

## Changes proposed

### What were you told to do?
I was tasked with exposing user prediction history in the UI by calling the existing backend endpoint and rendering results for the logged-in user.

Requirements included:
- Use `GET /api/predictions/user/:userId` to fetch the user's predictions
- Display prediction history in the UI
- Handle API errors and surface them to the user

### What did I do?

#### Added prediction history API support
Updated `src/lib/api-client.ts` with:
- `UserPrediction` type
- `predictionsApi.getUserHistory(userId)`
- Response normalization to support array/object response shapes

#### Added PredictionHistory UI component
Created `src/components/PredictionHistory.tsx` with:
- Fetch logic for `GET /api/predictions/user/:userId`
- Loading state
- Empty state
- Error state with visible retry action
- Rendered list of prediction entries (direction, stake, timestamp, and optional fields)

#### Wired Dashboard to logged-in user identity
Updated `src/pages/Dashboard.tsx` to:
- Read `publicKey` from wallet store
- Render `PredictionHistory` and pass `publicKey` as `userId`

#### Validation and results
- Attempted `npm run build`
- Local workspace is missing required type definition packages (`vite/client`, `node`), so build validation could not complete in this environment

## Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] My commit messages styles matches our requested structure.
- [ ] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `npm run build` attempted locally
- Build blocked by missing local type definition packages (`vite/client`, `node`)
