### PR TITLE
Submit predictions to the backend API

### DIFF
--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -33,6 +33,13 @@ export interface UserPrediction {
     [key: string]: unknown;
 }
 
+export interface SubmitPredictionRequest {
+    direction: 'UP' | 'DOWN';
+    stake: string;
+    exactPrice?: string;
+    isLegend: boolean;
+}
+
 type UserPredictionsResponse =
     | UserPrediction[]
     | {
@@ -60,6 +67,12 @@ export const predictionsApi = {
     getUserHistory: async (userId: string) => {
         const response = await apiFetch<UserPredictionsResponse>(`/api/predictions/user/${encodeURIComponent(userId)}`);
         return normalizeUserPredictions(response);
+    },
+    submit: async (prediction: SubmitPredictionRequest) => {
+        return apiFetch<UserPrediction>('/api/predictions/submit', {
+            method: 'POST',
+            body: JSON.stringify(prediction),
+        });
     },
 };
 


### PR DESCRIPTION
## Description
Replaces local console.log with a real POST request to `/api/predictions/submit` so predictions are properly saved to the backend. Adds loading states and error/success message handling.

## Changes
- ✅ Added `submit` method to `predictionsApi` in `api-client.ts`
- ✅ Replaced `console.log` in Dashboard with API call to `/api/predictions/submit`
- ✅ Added loading states (buttons disabled during submission)
- ✅ Added success message ("Prediction Sent!") that auto-dismisses after 3 seconds
- ✅ Added error handling with specific API error messages displayed to user

## Testing
- [x] UP/DOWN buttons submit predictions to the API
- [x] Loading states disable buttons during submission
- [x] Success messages are displayed on successful submission
- [x] Error messages are displayed on API failures

closes #42