### PR TITLE
refactor: API client error normalization and typed responses (closes #74)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -107,6 +107,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -476,6 +477,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -499,6 +501,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2444,8 +2447,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2530,6 +2532,7 @@
       "integrity": "sha512-OowOUbD1lBCOFIPOZ8xnMIhgqA4sCutMiYOmPHL1PTLt5+y1XA+g2+yC9OOyz8p+deMZqPZLxfMjYIfrKsPeFg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2540,6 +2543,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2550,6 +2554,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2606,6 +2611,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2980,6 +2986,7 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -3016,6 +3023,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3290,6 +3298,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3591,7 +3600,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -3695,8 +3705,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3919,6 +3928,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4769,6 +4779,7 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -5193,7 +5204,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5536,6 +5546,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5597,7 +5608,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5613,7 +5623,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5671,6 +5680,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5680,6 +5690,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5709,8 +5720,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -6504,6 +6514,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6670,6 +6681,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6745,6 +6757,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -7082,6 +7095,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -47,20 +47,29 @@ type UserPredictionsResponse =
         data?: UserPrediction[];
     };
 
-function normalizeUserPredictions(response: UserPredictionsResponse): UserPrediction[] {
+function normalizeArrayResponse<T>(
+    response: T[] | Record<string, unknown>,
+    keys: string[]
+): T[] {
     if (Array.isArray(response)) {
         return response;
     }
 
-    if (Array.isArray(response.predictions)) {
-        return response.predictions;
-    }
-
-    if (Array.isArray(response.data)) {
-        return response.data;
+    for (const key of keys) {
+        const value = response[key];
+        if (Array.isArray(value)) {
+            return value as T[];
+        }
     }
 
     return [];
+}
+
+function normalizeUserPredictions(response: UserPredictionsResponse): UserPrediction[] {
+    return normalizeArrayResponse<UserPrediction>(
+        response as UserPrediction[] | Record<string, unknown>,
+        ['predictions', 'data']
+    );
 }
 
 export const predictionsApi = {
@@ -151,10 +160,10 @@ export interface LeaderboardEntry {
 type LeaderboardResponse = LeaderboardEntry[] | { data?: LeaderboardEntry[]; leaderboard?: LeaderboardEntry[] };
 
 function normalizeLeaderboard(response: LeaderboardResponse): LeaderboardEntry[] {
-    if (Array.isArray(response)) return response;
-    if (Array.isArray(response.data)) return response.data;
-    if (Array.isArray(response.leaderboard)) return response.leaderboard;
-    return [];
+    return normalizeArrayResponse<LeaderboardEntry>(
+        response as LeaderboardEntry[] | Record<string, unknown>,
+        ['data', 'leaderboard']
+    );
 }
 
 export const leaderboardApi = {

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const clearAuthMock = vi.fn();
+
+vi.mock('../store/useAuthStore', () => ({
+  useAuthStore: {
+    getState: () => ({
+      jwt: 'test-jwt',
+      clearAuth: clearAuthMock,
+    }),
+  },
+}));
+
+describe('apiFetch', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    clearAuthMock.mockReset();
+  });
+
+  it('returns JSON on 200', async () => {
+    const payload = { ok: true };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).resolves.toEqual(payload);
+  });
+
+  it('throws typed error on 400 with backend message', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message: 'Bad request payload', code: 'BAD_REQUEST' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).rejects.toMatchObject({
+      message: 'Bad request payload',
+      status: 400,
+      code: 'BAD_REQUEST',
+    });
+  });
+
+  it('clears auth and throws on 401', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).rejects.toMatchObject({ status: 401 });
+    expect(clearAuthMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses actionable fallback message on 500', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('Internal Error', { status: 500 }))
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).rejects.toMatchObject({
+      status: 500,
+      message: 'Server error. Please try again shortly.',
+    });
+  });
+
+  it('throws timeout code on aborted request', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('Aborted', 'AbortError'));
+          });
+        });
+      })
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test', { timeoutMs: 1 })).rejects.toMatchObject({
+      code: 'TIMEOUT',
+      message: 'Request timed out. Please try again.',
+    });
+  });
+});
+

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,23 +1,88 @@
 import { useAuthStore } from '../store/useAuthStore';
 
 const API_BASE = import.meta.env.VITE_API_URL ?? '';
+const DEFAULT_TIMEOUT_MS = 15000;
 
 export interface ApiErrorShape {
   message: string;
   status: number;
+  code?: string;
+  details?: unknown;
 }
 
 export class ApiError extends Error {
   status: number;
-  constructor(message: string, status: number) {
+  code?: string;
+  details?: unknown;
+  endpoint?: string;
+
+  constructor(message: string, status: number, code?: string, details?: unknown, endpoint?: string) {
     super(message);
     this.status = status;
+    this.code = code;
+    this.details = details;
+    this.endpoint = endpoint;
     this.name = 'ApiError';
   }
 }
 
-export async function apiFetch<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+export interface ApiFetchOptions extends RequestInit {
+  timeoutMs?: number;
+}
+
+interface ErrorPayload {
+  message?: unknown;
+  error?: unknown;
+  code?: unknown;
+  details?: unknown;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+async function parseErrorPayload(response: Response): Promise<ErrorPayload | null> {
+  try {
+    const clone = response.clone();
+    const json = await clone.json();
+    return (json && typeof json === 'object') ? (json as ErrorPayload) : null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultMessageForStatus(status: number, endpoint: string): string {
+  if (status === 400) return 'Invalid request. Please check your input and try again.';
+  if (status === 401) return 'Your session has expired. Please reconnect and try again.';
+  if (status === 403) return 'You do not have permission to perform this action.';
+  if (status === 404) return 'Requested resource was not found.';
+  if (status >= 500) return 'Server error. Please try again shortly.';
+  return `Request failed: ${endpoint}`;
+}
+
+function createApiError(endpoint: string, status: number, payload: ErrorPayload | null): ApiError {
+  const message =
+    asString(payload?.message) ??
+    asString(payload?.error) ??
+    defaultMessageForStatus(status, endpoint);
+  const code = asString(payload?.code) ?? undefined;
+  const details = payload?.details;
+  return new ApiError(message, status, code, details, endpoint);
+}
+
+export function normalizeApiError(error: unknown, fallbackMessage = 'Something went wrong. Please try again.'): ApiError {
+  if (error instanceof ApiError) {
+    return error;
+  }
+  if (error instanceof Error) {
+    return new ApiError(error.message || fallbackMessage, 0, 'UNKNOWN', undefined);
+  }
+  return new ApiError(fallbackMessage, 0, 'UNKNOWN', undefined);
+}
+
+export async function apiFetch<T>(endpoint: string, options: ApiFetchOptions = {}): Promise<T> {
   const { jwt, clearAuth } = useAuthStore.getState();
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -28,20 +93,47 @@ export async function apiFetch<T>(endpoint: string, options: RequestInit = {}): 
     headers['Authorization'] = `Bearer ${jwt}`;
   }
 
-  const response = await fetch(`${API_BASE}${endpoint}`, {
-    ...options,
-    headers,
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const requestOptions: RequestInit = { ...options };
+  delete (requestOptions as Record<string, unknown>).timeoutMs;
 
-  if (response.status === 401) {
-    clearAuth();
-    throw new ApiError('Unauthorized: session expired', 401);
+  try {
+    const response = await fetch(`${API_BASE}${endpoint}`, {
+      ...requestOptions,
+      headers,
+      signal: requestOptions.signal ?? controller.signal,
+    });
+
+    if (response.status === 401) {
+      clearAuth();
+    }
+
+    if (!response.ok) {
+      const payload = await parseErrorPayload(response);
+      const apiError = createApiError(endpoint, response.status, payload);
+      if (import.meta.env.DEV) {
+        console.debug('[apiFetch:error]', {
+          endpoint,
+          status: apiError.status,
+          code: apiError.code,
+          message: apiError.message,
+        });
+      }
+      throw apiError;
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return response.json() as Promise<T>;
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new ApiError('Request timed out. Please try again.', 0, 'TIMEOUT', undefined, endpoint);
+    }
+    throw normalizeApiError(error, 'Network error. Please check your connection and try again.');
+  } finally {
+    clearTimeout(timeout);
   }
-
-  if (!response.ok) {
-    const text = await response.text().catch(() => response.statusText);
-    throw new ApiError(text || `Request failed: ${endpoint}`, response.status);
-  }
-
-  return response.json() as Promise<T>;
 }

--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from "react";
 import { educationApi } from "../lib/api-client";
+import { normalizeApiError } from "../lib/api";
 import type { Guide, Tip } from "../types/education";
 import { GuideCard } from "../components/education/GuideCard";
 import { TipCard } from "../components/education/TipCard";
@@ -25,7 +26,8 @@ const LearnPage = () => {
             if (guidesResult.status === 'fulfilled') {
                 setGuides(guidesResult.value);
             } else {
-                console.error("Failed to fetch guides:", guidesResult.reason);
+                const err = normalizeApiError(guidesResult.reason, "Failed to fetch guides");
+                console.debug("Failed to fetch guides", { message: err.message, status: err.status, code: err.code });
                 // We only set a general error if both or critical one fails, 
                 // but requirement says "one failure does not block the other"
             }
@@ -33,7 +35,8 @@ const LearnPage = () => {
             if (tipResult.status === 'fulfilled') {
                 setTip(tipResult.value);
             } else {
-                console.error("Failed to fetch tip:", tipResult.reason);
+                const err = normalizeApiError(tipResult.reason, "Failed to fetch tip");
+                console.debug("Failed to fetch tip", { message: err.message, status: err.status, code: err.code });
             }
 
             // If both failed, show error
@@ -41,7 +44,8 @@ const LearnPage = () => {
                 setError("Unable to load education content. Please check your connection.");
             }
         } catch (err) {
-            setError(err instanceof Error ? err.message : "An unexpected error occurred");
+            const normalized = normalizeApiError(err, "An unexpected error occurred");
+            setError(normalized.message);
         } finally {
             setLoading(false);
         }

--- a/src/store/useNotificationsStore.ts
+++ b/src/store/useNotificationsStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import type { NotificationItem, NotificationEventPayload } from '../types/notification';
 import { notificationsApi } from '../lib/api-client';
+import { normalizeApiError } from '../lib/api';
 
 interface NotificationsState {
   unread: number;
@@ -29,8 +30,8 @@ export const useNotificationsStore = create<NotificationsState>()((set, get) => 
       const res = await notificationsApi.getUnreadCount();
       set({ unread: res.unread });
     } catch (rawErr) {
-      const msg = rawErr instanceof Error ? rawErr.message : 'Failed to load unread count';
-      set({ errorCount: msg });
+      const err = normalizeApiError(rawErr, 'Failed to load unread count');
+      set({ errorCount: err.message });
     } finally {
       set({ loadingCount: false });
     }
@@ -49,8 +50,8 @@ export const useNotificationsStore = create<NotificationsState>()((set, get) => 
         return { list: merged };
       });
     } catch (rawErr) {
-      const msg = rawErr instanceof Error ? rawErr.message : 'Failed to load notifications';
-      set({ errorList: msg });
+      const err = normalizeApiError(rawErr, 'Failed to load notifications');
+      set({ errorList: err.message });
     } finally {
       set({ loadingList: false });
     }

--- a/src/store/useProfileStore.ts
+++ b/src/store/useProfileStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { useAuthStore } from './useAuthStore';
+import { normalizeApiError } from '../lib/api';
 import {
   fetchProfile,
   updateProfile,
@@ -57,11 +58,12 @@ export const useProfileStore = create<ProfileState>((set) => ({
       writeLocalCache(data);
       set({ profile: data, isLoading: false, error: null });
     } catch (err) {
+      const normalized = normalizeApiError(err, 'Failed to load profile');
       const cached = readLocalCache();
       set({
         profile: cached,
         isLoading: false,
-        error: err instanceof Error ? err.message : 'Failed to load profile',
+        error: normalized.message,
       });
     }
   },
@@ -81,10 +83,11 @@ export const useProfileStore = create<ProfileState>((set) => ({
       set({ profile: saved, error: null });
       return true;
     } catch (err) {
+      const normalized = normalizeApiError(err, 'Failed to save profile');
       writeLocalCache(data);
       set({
         profile: data,
-        error: err instanceof Error ? err.message : 'Failed to save profile',
+        error: normalized.message,
       });
       return false;
     }

--- a/src/store/useRoundStore.test.ts
+++ b/src/store/useRoundStore.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../lib/api-client', () => ({
+  roundsApi: {
+    getActive: vi.fn(),
+  },
+}));
+
+import { roundsApi } from '../lib/api-client';
+import { useRoundStore } from './useRoundStore';
+import { ApiError } from '../lib/api';
+
+describe('useRoundStore error handling', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    useRoundStore.setState({
+      activeRound: null,
+      isRoundActive: false,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('sets actionable message when round fetch fails with ApiError', async () => {
+    vi.mocked(roundsApi.getActive).mockRejectedValueOnce(
+      new ApiError('Server error. Please try again shortly.', 500, 'INTERNAL')
+    );
+
+    await useRoundStore.getState().fetchActiveRound();
+
+    const state = useRoundStore.getState();
+    expect(state.activeRound).toBeNull();
+    expect(state.isRoundActive).toBe(false);
+    expect(state.error).toBe('Server error. Please try again shortly.');
+  });
+});
+

--- a/src/store/useRoundStore.ts
+++ b/src/store/useRoundStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { roundsApi, type Round } from '../lib/api-client';
+import { normalizeApiError } from '../lib/api';
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 
@@ -78,11 +79,12 @@ export const useRoundStore = create<RoundStore>((set) => ({
       const activeRound = await roundsApi.getActive();
       set({ activeRound, isRoundActive: !!activeRound, isLoading: false });
     } catch (error) {
+      const normalized = normalizeApiError(error, 'Failed to fetch active round');
       set({
         activeRound: null,
         isRoundActive: false,
         isLoading: false,
-        error: error instanceof Error ? error.message : 'Failed to fetch active round',
+        error: normalized.message,
       });
     }
   },


### PR DESCRIPTION
## Summary
Refactors the API client layer to provide consistent typed error contracts and response normalization across stores/pages.

## What changed
- `src/lib/api.ts`
  - Added normalized `ApiError` contract with `message`, `status`, optional `code`, `details`, and `endpoint`
  - Added `normalizeApiError()` helper for safe, consistent UI/store consumption
  - Standardized `apiFetch()` behavior:
    - typed error extraction from backend payloads
    - actionable fallback messages by status class
    - consistent 401 auth reset behavior
    - timeout support with `TIMEOUT` code
    - developer diagnostics in dev mode (without exposing sensitive payload details)
- `src/lib/api-client.ts`
  - Added reusable list normalization helper for envelope/array responses
  - Applied normalization for predictions and leaderboard responses
- Store/Page integration
  - `src/store/useNotificationsStore.ts`
  - `src/store/useRoundStore.ts`
  - `src/store/useProfileStore.ts`
  - `src/pages/Learn.tsx`
  - Removed ad hoc raw error parsing and standardized on `normalizeApiError()`

## Tests
- Added `src/lib/api.test.ts` for `apiFetch` scenarios:
  - 200 success
  - 400 typed backend error
  - 401 auth reset
  - 500 fallback server message
  - timeout/network-abort handling
- Added `src/store/useRoundStore.test.ts` for store-level user-visible error behavior
- Full pipeline passes locally: `npm run test` (lint + build + unit tests)

## Acceptance criteria mapping
- [x] Shared API helpers now use consistent typed response/error behavior
- [x] UI/store layers no longer parse raw response errors directly
- [x] Unauthorized flow consistently clears auth
- [x] User-facing messages are actionable and normalized
- [x] Unit tests cover 200/400/401/500/timeout and store-level failure behavior

Closes #74

Made with [Cursor](https://cursor.com)