### PR TITLE
feat(wallet): connection state machine, Dashboard wiring, tests (#71)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -107,6 +107,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -476,6 +477,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -499,6 +501,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2444,8 +2447,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2530,6 +2532,7 @@
       "integrity": "sha512-OowOUbD1lBCOFIPOZ8xnMIhgqA4sCutMiYOmPHL1PTLt5+y1XA+g2+yC9OOyz8p+deMZqPZLxfMjYIfrKsPeFg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2540,6 +2543,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2550,6 +2554,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2606,6 +2611,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2980,6 +2986,7 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -3016,6 +3023,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3290,6 +3298,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3591,7 +3600,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -3695,8 +3705,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3919,6 +3928,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4769,6 +4779,7 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -5193,7 +5204,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5536,6 +5546,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5597,7 +5608,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5613,7 +5623,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5671,6 +5680,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5680,6 +5690,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5709,8 +5720,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -6504,6 +6514,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6670,6 +6681,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6745,6 +6757,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -7082,6 +7095,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/PredictionCard.tsx
+++ b/src/components/PredictionCard.tsx
@@ -5,6 +5,7 @@ interface PredictionCardProps {
   isWalletConnected?: boolean;
   isRoundActive?: boolean;
   isConnecting?: boolean;
+  isSubmittingPrediction?: boolean;
   onPrediction?: (prediction: PredictionData) => void;
 }
 
@@ -12,10 +13,12 @@ const PredictionCard = ({
   isWalletConnected = false,
   isRoundActive = true,
   isConnecting = false,
+  isSubmittingPrediction = false,
   onPrediction,
 }: PredictionCardProps) => {
 
-  const isDisabled = !isWalletConnected || !isRoundActive || isConnecting;
+  const isDisabled =
+    !isWalletConnected || !isRoundActive || isConnecting || isSubmittingPrediction;
 
   return (
     <div
@@ -26,6 +29,7 @@ const PredictionCard = ({
         isWalletConnected={isWalletConnected}
         isRoundActive={isRoundActive}
         isConnecting={isConnecting}
+        isSubmittingPrediction={isSubmittingPrediction}
         onPrediction={onPrediction}
       />
 

--- a/src/components/PredictionControls.tsx
+++ b/src/components/PredictionControls.tsx
@@ -15,7 +15,10 @@ export interface PredictionData {
 export interface PredictionControlsProps {
   isWalletConnected?: boolean;
   isRoundActive?: boolean;
+  /** Wallet/session connecting (e.g. Freighter flow). */
   isConnecting?: boolean;
+  /** Prediction submit in flight (distinct from wallet connecting). */
+  isSubmittingPrediction?: boolean;
   onPrediction?: (prediction: PredictionData) => void;
 }
 
@@ -37,6 +40,7 @@ export function PredictionControls({
   isWalletConnected = false,
   isRoundActive = true,
   isConnecting = false,
+  isSubmittingPrediction = false,
   onPrediction,
 }: PredictionControlsProps) {
   const [stake, setStake] = useState("");
@@ -46,7 +50,8 @@ export function PredictionControls({
   const [selectedDirection, setSelectedDirection] = useState<"UP" | "DOWN" | null>(null);
   const [touchedExactPrice, setTouchedExactPrice] = useState(false);
 
-  const isDisabled = !isWalletConnected || !isRoundActive || isConnecting;
+  const isDisabled =
+    !isWalletConnected || !isRoundActive || isConnecting || isSubmittingPrediction;
 
   const validateExactPriceField = useCallback(() => {
     if (!isLegend) return;
@@ -108,7 +113,12 @@ export function PredictionControls({
 
       {isConnecting && (
         <p className="prediction-card__connecting" role="status">
-          Connecting...
+          Connecting wallet...
+        </p>
+      )}
+      {isSubmittingPrediction && !isConnecting && (
+        <p className="prediction-card__connecting" role="status">
+          Submitting prediction...
         </p>
       )}
 
@@ -222,7 +232,7 @@ export function PredictionControls({
         </div>
       )}
 
-      {isDisabled && !isConnecting && (
+      {isDisabled && !isConnecting && !isSubmittingPrediction && (
         <div className="prediction-card__disabled-message">
           {!isWalletConnected && <p>Connect your wallet to make predictions</p>}
           {isWalletConnected && !isRoundActive && <p>This round is not active</p>}

--- a/src/components/WalletConnect.tsx
+++ b/src/components/WalletConnect.tsx
@@ -1,93 +1,129 @@
 import { useEffect } from 'react';
 import { useWalletStore } from '../store/useWalletStore';
 import { useAuthStore } from '../store/useAuthStore';
-import { Loader2, AlertCircle, LogOut, Wallet, ShieldCheck } from 'lucide-react';
+import { Loader2, AlertCircle, LogOut, Wallet, ShieldCheck, RefreshCw } from 'lucide-react';
 import clsx from 'clsx';
 
-
 const WalletConnect = () => {
-    const {
-        publicKey,
-        balance,
-        network,
-        isConnecting,
-        connect,
-        disconnect,
-        checkConnection
-    } = useWalletStore();
-    const { isAuthenticated } = useAuthStore();
+  const {
+    publicKey,
+    balance,
+    status,
+    errorMessage,
+    networkMismatch,
+    connect,
+    disconnect,
+    checkConnection,
+    clearError,
+  } = useWalletStore();
+  const { isAuthenticated } = useAuthStore();
 
-    useEffect(() => {
-        checkConnection();
-    }, [checkConnection]);
+  useEffect(() => {
+    void checkConnection();
+  }, [checkConnection]);
 
+  const shortAddress = publicKey
+    ? `${publicKey.slice(0, 4)}...${publicKey.slice(-4)}`
+    : '';
 
-
-    const shortAddress = publicKey
-        ? `${publicKey.slice(0, 4)}...${publicKey.slice(-4)}`
-        : '';
-
-    if (publicKey) {
-        return (
-            <div className="flex items-center gap-3">
-                {network !== 'TESTNET' && (
-                    <div className="hidden md:flex items-center text-red-500 text-sm font-medium bg-red-50 dark:bg-red-900/20 px-2 py-1 rounded">
-                        <AlertCircle className="w-4 h-4 mr-1" />
-                        Testnet Only
-                    </div>
-                )}
-
-                <div className="hidden md:flex items-center gap-2 px-3 py-1.5 bg-white dark:bg-gray-800 border border-[#BEC7FE] dark:border-gray-700 rounded-lg shadow-sm">
-                    <span className="text-sm font-semibold text-[#4D4D4D] dark:text-gray-300">
-                        {balance}
-                    </span>
-                </div>
-
-                <div className="flex items-center gap-2 p-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg pr-3 relative group">
-                    <div className="w-8 h-8 rounded-full bg-gradient-to-tr from-blue-500 to-purple-500 flex items-center justify-center text-white text-xs">
-                        <Wallet className="w-4 h-4" />
-                    </div>
-                    <span className="text-sm font-medium text-gray-700 dark:text-gray-200">
-                        {shortAddress}
-                    </span>
-                    {isAuthenticated && (
-                        <ShieldCheck className="w-4 h-4 text-green-500" aria-label="Authenticated with backend" />
-                    )}
-
-                    <button
-                        onClick={disconnect}
-                        className="absolute top-full right-0 mt-2 w-full min-w-[120px] bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-lg shadow-lg py-2 px-3 flex items-center gap-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/10 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
-                        <LogOut className="w-4 h-4" />
-                        <span className="text-sm cursor-pointer">Disconnect</span>
-                    </button>
-                </div>
-            </div>
-        );
-    }
-
+  if (publicKey && status === 'connected') {
     return (
-        <button
-            onClick={connect}
-            disabled={isConnecting}
-            className={clsx(
-                "flex items-center gap-2 px-4 py-2 rounded-lg font-semibold transition-all duration-200 cursor-pointer",
-                "bg-[#2C4BFD] hover:bg-[#1a3bf0] text-white shadow-lg shadow-blue-500/20",
-                "disabled:opacity-70 disabled:cursor-not-allowed"
-            )}
-        >
-            {isConnecting ? (
-                <>
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                    <span>Connecting...</span>
-                </>
-            ) : (
-                <>
-                    <Wallet className="w-4 h-4" />
-                    <span>Connect Wallet</span>
-                </>
-            )}
-        </button>
+      <div className="flex items-center gap-3">
+        {networkMismatch && (
+          <div
+            className="hidden md:flex items-center text-red-500 text-sm font-medium bg-red-50 dark:bg-red-900/20 px-2 py-1 rounded"
+            role="status"
+          >
+            <AlertCircle className="w-4 h-4 mr-1 shrink-0" aria-hidden />
+            Switch to Testnet in Freighter
+          </div>
+        )}
+
+        <div className="hidden md:flex items-center gap-2 px-3 py-1.5 bg-white dark:bg-gray-800 border border-[#BEC7FE] dark:border-gray-700 rounded-lg shadow-sm">
+          <span className="text-sm font-semibold text-[#4D4D4D] dark:text-gray-300">
+            {balance ?? '—'}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2 p-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg pr-3 relative group">
+          <div
+            className="w-8 h-8 rounded-full bg-gradient-to-tr from-blue-500 to-purple-500 flex items-center justify-center text-white text-xs"
+            aria-hidden
+          >
+            <Wallet className="w-4 h-4" />
+          </div>
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-200">{shortAddress}</span>
+          {isAuthenticated && (
+            <ShieldCheck className="w-4 h-4 text-green-500" aria-label="Authenticated with backend" />
+          )}
+
+          <button
+            type="button"
+            onClick={disconnect}
+            className="absolute top-full right-0 mt-2 w-full min-w-[120px] bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-lg shadow-lg py-2 px-3 flex items-center gap-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/10 opacity-0 invisible group-hover:opacity-100 group-hover:visible group-focus-within:opacity-100 group-focus-within:visible transition-all duration-200 z-50"
+            aria-label="Disconnect wallet"
+          >
+            <LogOut className="w-4 h-4 shrink-0" aria-hidden />
+            <span className="text-sm">Disconnect</span>
+          </button>
+        </div>
+      </div>
     );
+  }
+
+  if (status === 'error' && errorMessage) {
+    return (
+      <div className="flex flex-col items-end gap-2 sm:flex-row sm:items-center sm:gap-3">
+        <p className="text-xs sm:text-sm text-red-600 dark:text-red-400 max-w-[220px] sm:max-w-xs text-right sm:text-left">
+          {errorMessage}
+        </p>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              clearError();
+              void connect();
+            }}
+            className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-semibold bg-[#2C4BFD] text-white hover:bg-[#1a3bf0]"
+          >
+            <RefreshCw className="w-4 h-4" aria-hidden />
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => void connect()}
+      disabled={status === 'connecting' || status === 'checking'}
+      className={clsx(
+        'flex items-center gap-2 px-4 py-2 rounded-lg font-semibold transition-all duration-200',
+        'bg-[#2C4BFD] hover:bg-[#1a3bf0] text-white shadow-lg shadow-blue-500/20',
+        'disabled:opacity-70 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2C4BFD]'
+      )}
+      aria-busy={status === 'connecting' || status === 'checking'}
+    >
+      {status === 'connecting' ? (
+        <>
+          <Loader2 className="w-4 h-4 animate-spin" aria-hidden />
+          <span>Connecting…</span>
+        </>
+      ) : status === 'checking' ? (
+        <>
+          <Loader2 className="w-4 h-4 animate-spin" aria-hidden />
+          <span>Checking wallet…</span>
+        </>
+      ) : (
+        <>
+          <Wallet className="w-4 h-4" aria-hidden />
+          <span>Connect Wallet</span>
+        </>
+      )}
+    </button>
+  );
 };
 
 export default WalletConnect;

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -47,20 +47,29 @@ type UserPredictionsResponse =
         data?: UserPrediction[];
     };
 
-function normalizeUserPredictions(response: UserPredictionsResponse): UserPrediction[] {
+function normalizeArrayResponse<T>(
+    response: T[] | Record<string, unknown>,
+    keys: string[]
+): T[] {
     if (Array.isArray(response)) {
         return response;
     }
 
-    if (Array.isArray(response.predictions)) {
-        return response.predictions;
-    }
-
-    if (Array.isArray(response.data)) {
-        return response.data;
+    for (const key of keys) {
+        const value = response[key];
+        if (Array.isArray(value)) {
+            return value as T[];
+        }
     }
 
     return [];
+}
+
+function normalizeUserPredictions(response: UserPredictionsResponse): UserPrediction[] {
+    return normalizeArrayResponse<UserPrediction>(
+        response as UserPrediction[] | Record<string, unknown>,
+        ['predictions', 'data']
+    );
 }
 
 export const predictionsApi = {
@@ -151,10 +160,10 @@ export interface LeaderboardEntry {
 type LeaderboardResponse = LeaderboardEntry[] | { data?: LeaderboardEntry[]; leaderboard?: LeaderboardEntry[] };
 
 function normalizeLeaderboard(response: LeaderboardResponse): LeaderboardEntry[] {
-    if (Array.isArray(response)) return response;
-    if (Array.isArray(response.data)) return response.data;
-    if (Array.isArray(response.leaderboard)) return response.leaderboard;
-    return [];
+    return normalizeArrayResponse<LeaderboardEntry>(
+        response as LeaderboardEntry[] | Record<string, unknown>,
+        ['data', 'leaderboard']
+    );
 }
 
 export const leaderboardApi = {

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const clearAuthMock = vi.fn();
+
+vi.mock('../store/useAuthStore', () => ({
+  useAuthStore: {
+    getState: () => ({
+      jwt: 'test-jwt',
+      clearAuth: clearAuthMock,
+    }),
+  },
+}));
+
+describe('apiFetch', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    clearAuthMock.mockReset();
+  });
+
+  it('returns JSON on 200', async () => {
+    const payload = { ok: true };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).resolves.toEqual(payload);
+  });
+
+  it('throws typed error on 400 with backend message', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message: 'Bad request payload', code: 'BAD_REQUEST' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).rejects.toMatchObject({
+      message: 'Bad request payload',
+      status: 400,
+      code: 'BAD_REQUEST',
+    });
+  });
+
+  it('clears auth and throws on 401', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).rejects.toMatchObject({ status: 401 });
+    expect(clearAuthMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses actionable fallback message on 500', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('Internal Error', { status: 500 }))
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).rejects.toMatchObject({
+      status: 500,
+      message: 'Server error. Please try again shortly.',
+    });
+  });
+
+  it('throws timeout code on aborted request', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('Aborted', 'AbortError'));
+          });
+        });
+      })
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test', { timeoutMs: 1 })).rejects.toMatchObject({
+      code: 'TIMEOUT',
+      message: 'Request timed out. Please try again.',
+    });
+  });
+});
+

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,23 +1,88 @@
 import { useAuthStore } from '../store/useAuthStore';
 
 const API_BASE = import.meta.env.VITE_API_URL ?? '';
+const DEFAULT_TIMEOUT_MS = 15000;
 
 export interface ApiErrorShape {
   message: string;
   status: number;
+  code?: string;
+  details?: unknown;
 }
 
 export class ApiError extends Error {
   status: number;
-  constructor(message: string, status: number) {
+  code?: string;
+  details?: unknown;
+  endpoint?: string;
+
+  constructor(message: string, status: number, code?: string, details?: unknown, endpoint?: string) {
     super(message);
     this.status = status;
+    this.code = code;
+    this.details = details;
+    this.endpoint = endpoint;
     this.name = 'ApiError';
   }
 }
 
-export async function apiFetch<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+export interface ApiFetchOptions extends RequestInit {
+  timeoutMs?: number;
+}
+
+interface ErrorPayload {
+  message?: unknown;
+  error?: unknown;
+  code?: unknown;
+  details?: unknown;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+async function parseErrorPayload(response: Response): Promise<ErrorPayload | null> {
+  try {
+    const clone = response.clone();
+    const json = await clone.json();
+    return (json && typeof json === 'object') ? (json as ErrorPayload) : null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultMessageForStatus(status: number, endpoint: string): string {
+  if (status === 400) return 'Invalid request. Please check your input and try again.';
+  if (status === 401) return 'Your session has expired. Please reconnect and try again.';
+  if (status === 403) return 'You do not have permission to perform this action.';
+  if (status === 404) return 'Requested resource was not found.';
+  if (status >= 500) return 'Server error. Please try again shortly.';
+  return `Request failed: ${endpoint}`;
+}
+
+function createApiError(endpoint: string, status: number, payload: ErrorPayload | null): ApiError {
+  const message =
+    asString(payload?.message) ??
+    asString(payload?.error) ??
+    defaultMessageForStatus(status, endpoint);
+  const code = asString(payload?.code) ?? undefined;
+  const details = payload?.details;
+  return new ApiError(message, status, code, details, endpoint);
+}
+
+export function normalizeApiError(error: unknown, fallbackMessage = 'Something went wrong. Please try again.'): ApiError {
+  if (error instanceof ApiError) {
+    return error;
+  }
+  if (error instanceof Error) {
+    return new ApiError(error.message || fallbackMessage, 0, 'UNKNOWN', undefined);
+  }
+  return new ApiError(fallbackMessage, 0, 'UNKNOWN', undefined);
+}
+
+export async function apiFetch<T>(endpoint: string, options: ApiFetchOptions = {}): Promise<T> {
   const { jwt, clearAuth } = useAuthStore.getState();
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -28,20 +93,47 @@ export async function apiFetch<T>(endpoint: string, options: RequestInit = {}): 
     headers['Authorization'] = `Bearer ${jwt}`;
   }
 
-  const response = await fetch(`${API_BASE}${endpoint}`, {
-    ...options,
-    headers,
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const requestOptions: RequestInit = { ...options };
+  delete (requestOptions as Record<string, unknown>).timeoutMs;
 
-  if (response.status === 401) {
-    clearAuth();
-    throw new ApiError('Unauthorized: session expired', 401);
+  try {
+    const response = await fetch(`${API_BASE}${endpoint}`, {
+      ...requestOptions,
+      headers,
+      signal: requestOptions.signal ?? controller.signal,
+    });
+
+    if (response.status === 401) {
+      clearAuth();
+    }
+
+    if (!response.ok) {
+      const payload = await parseErrorPayload(response);
+      const apiError = createApiError(endpoint, response.status, payload);
+      if (import.meta.env.DEV) {
+        console.debug('[apiFetch:error]', {
+          endpoint,
+          status: apiError.status,
+          code: apiError.code,
+          message: apiError.message,
+        });
+      }
+      throw apiError;
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return response.json() as Promise<T>;
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new ApiError('Request timed out. Please try again.', 0, 'TIMEOUT', undefined, endpoint);
+    }
+    throw normalizeApiError(error, 'Network error. Please check your connection and try again.');
+  } finally {
+    clearTimeout(timeout);
   }
-
-  if (!response.ok) {
-    const text = await response.text().catch(() => response.statusText);
-    throw new ApiError(text || `Request failed: ${endpoint}`, response.status);
-  }
-
-  return response.json() as Promise<T>;
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,7 +5,7 @@ import PredictionCard from "../components/PredictionCard";
 import type { PredictionData } from "../components/PredictionControls";
 import { useRoundStore } from "../store/useRoundStore";
 import PredictionHistory from "../components/PredictionHistory";
-import { useWalletStore } from "../store/useWalletStore";
+import { useWalletStore, selectIsWalletConnected } from "../store/useWalletStore";
 import { predictionsApi, ApiError } from "../lib/api-client";
 
 interface DashboardProps {
@@ -14,7 +14,11 @@ interface DashboardProps {
 
 const Dashboard = ({ showNewsRibbon = true }: DashboardProps) => {
   const isRoundActive = useRoundStore((state) => state.isRoundActive);
-  const publicKey = useWalletStore((state) => state.publicKey);
+  const isWalletConnected = useWalletStore(selectIsWalletConnected);
+  const isWalletConnecting = useWalletStore(
+    (s) => s.status === "connecting" || s.status === "checking"
+  );
+  const publicKey = useWalletStore((s) => s.publicKey);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const timeoutRef = useRef<number | null>(null);
@@ -98,9 +102,10 @@ const Dashboard = ({ showNewsRibbon = true }: DashboardProps) => {
           {/* Center: Prediction controls (Issue: core prediction area) */}
           <div className="dashboard__center lg:col-span-1 flex flex-col gap-6">
             <PredictionCard
-              isWalletConnected={true}
+              isWalletConnected={isWalletConnected}
               isRoundActive={isRoundActive}
-              isConnecting={isSubmitting}
+              isConnecting={isWalletConnecting}
+              isSubmittingPrediction={isSubmitting}
               onPrediction={handlePrediction}
             />
           </div>

--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from "react";
 import { educationApi } from "../lib/api-client";
+import { normalizeApiError } from "../lib/api";
 import type { Guide, Tip } from "../types/education";
 import { GuideCard } from "../components/education/GuideCard";
 import { TipCard } from "../components/education/TipCard";
@@ -25,7 +26,8 @@ const LearnPage = () => {
             if (guidesResult.status === 'fulfilled') {
                 setGuides(guidesResult.value);
             } else {
-                console.error("Failed to fetch guides:", guidesResult.reason);
+                const err = normalizeApiError(guidesResult.reason, "Failed to fetch guides");
+                console.debug("Failed to fetch guides", { message: err.message, status: err.status, code: err.code });
                 // We only set a general error if both or critical one fails, 
                 // but requirement says "one failure does not block the other"
             }
@@ -33,7 +35,8 @@ const LearnPage = () => {
             if (tipResult.status === 'fulfilled') {
                 setTip(tipResult.value);
             } else {
-                console.error("Failed to fetch tip:", tipResult.reason);
+                const err = normalizeApiError(tipResult.reason, "Failed to fetch tip");
+                console.debug("Failed to fetch tip", { message: err.message, status: err.status, code: err.code });
             }
 
             // If both failed, show error
@@ -41,7 +44,8 @@ const LearnPage = () => {
                 setError("Unable to load education content. Please check your connection.");
             }
         } catch (err) {
-            setError(err instanceof Error ? err.message : "An unexpected error occurred");
+            const normalized = normalizeApiError(err, "An unexpected error occurred");
+            setError(normalized.message);
         } finally {
             setLoading(false);
         }

--- a/src/store/useNotificationsStore.ts
+++ b/src/store/useNotificationsStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import type { NotificationItem, NotificationEventPayload } from '../types/notification';
 import { notificationsApi } from '../lib/api-client';
+import { normalizeApiError } from '../lib/api';
 
 interface NotificationsState {
   unread: number;
@@ -29,8 +30,8 @@ export const useNotificationsStore = create<NotificationsState>()((set, get) => 
       const res = await notificationsApi.getUnreadCount();
       set({ unread: res.unread });
     } catch (rawErr) {
-      const msg = rawErr instanceof Error ? rawErr.message : 'Failed to load unread count';
-      set({ errorCount: msg });
+      const err = normalizeApiError(rawErr, 'Failed to load unread count');
+      set({ errorCount: err.message });
     } finally {
       set({ loadingCount: false });
     }
@@ -49,8 +50,8 @@ export const useNotificationsStore = create<NotificationsState>()((set, get) => 
         return { list: merged };
       });
     } catch (rawErr) {
-      const msg = rawErr instanceof Error ? rawErr.message : 'Failed to load notifications';
-      set({ errorList: msg });
+      const err = normalizeApiError(rawErr, 'Failed to load notifications');
+      set({ errorList: err.message });
     } finally {
       set({ loadingList: false });
     }

--- a/src/store/useProfileStore.ts
+++ b/src/store/useProfileStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { useAuthStore } from './useAuthStore';
+import { normalizeApiError } from '../lib/api';
 import {
   fetchProfile,
   updateProfile,
@@ -57,11 +58,12 @@ export const useProfileStore = create<ProfileState>((set) => ({
       writeLocalCache(data);
       set({ profile: data, isLoading: false, error: null });
     } catch (err) {
+      const normalized = normalizeApiError(err, 'Failed to load profile');
       const cached = readLocalCache();
       set({
         profile: cached,
         isLoading: false,
-        error: err instanceof Error ? err.message : 'Failed to load profile',
+        error: normalized.message,
       });
     }
   },
@@ -81,10 +83,11 @@ export const useProfileStore = create<ProfileState>((set) => ({
       set({ profile: saved, error: null });
       return true;
     } catch (err) {
+      const normalized = normalizeApiError(err, 'Failed to save profile');
       writeLocalCache(data);
       set({
         profile: data,
-        error: err instanceof Error ? err.message : 'Failed to save profile',
+        error: normalized.message,
       });
       return false;
     }

--- a/src/store/useRoundStore.test.ts
+++ b/src/store/useRoundStore.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../lib/api-client', () => ({
+  roundsApi: {
+    getActive: vi.fn(),
+  },
+}));
+
+import { roundsApi } from '../lib/api-client';
+import { useRoundStore } from './useRoundStore';
+import { ApiError } from '../lib/api';
+
+describe('useRoundStore error handling', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    useRoundStore.setState({
+      activeRound: null,
+      isRoundActive: false,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('sets actionable message when round fetch fails with ApiError', async () => {
+    vi.mocked(roundsApi.getActive).mockRejectedValueOnce(
+      new ApiError('Server error. Please try again shortly.', 500, 'INTERNAL')
+    );
+
+    await useRoundStore.getState().fetchActiveRound();
+
+    const state = useRoundStore.getState();
+    expect(state.activeRound).toBeNull();
+    expect(state.isRoundActive).toBe(false);
+    expect(state.error).toBe('Server error. Please try again shortly.');
+  });
+});
+

--- a/src/store/useRoundStore.ts
+++ b/src/store/useRoundStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { roundsApi, type Round } from '../lib/api-client';
+import { normalizeApiError } from '../lib/api';
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 
@@ -78,11 +79,12 @@ export const useRoundStore = create<RoundStore>((set) => ({
       const activeRound = await roundsApi.getActive();
       set({ activeRound, isRoundActive: !!activeRound, isLoading: false });
     } catch (error) {
+      const normalized = normalizeApiError(error, 'Failed to fetch active round');
       set({
         activeRound: null,
         isRoundActive: false,
         isLoading: false,
-        error: error instanceof Error ? error.message : 'Failed to fetch active round',
+        error: normalized.message,
       });
     }
   },

--- a/src/store/useWalletStore.test.ts
+++ b/src/store/useWalletStore.test.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const clearAuth = vi.fn();
+const setJwt = vi.fn();
+
+vi.mock('./useAuthStore', () => ({
+  useAuthStore: {
+    getState: () => ({
+      clearAuth,
+      setJwt,
+      isAuthenticated: false,
+    }),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@stellar/freighter-api', () => ({
+  isConnected: vi.fn(),
+  requestAccess: vi.fn(),
+  getAddress: vi.fn(),
+  getNetwork: vi.fn(),
+  signMessage: vi.fn(),
+}));
+
+import {
+  isConnected,
+  requestAccess,
+  getAddress,
+  getNetwork,
+  signMessage,
+} from '@stellar/freighter-api';
+import { useWalletStore, selectIsWalletConnected } from './useWalletStore';
+
+function resetWalletState() {
+  useWalletStore.setState({
+    status: 'idle',
+    publicKey: null,
+    network: null,
+    balance: null,
+    errorMessage: null,
+    errorCode: null,
+    networkMismatch: false,
+  });
+}
+
+describe('selectIsWalletConnected', () => {
+  beforeEach(() => {
+    resetWalletState();
+  });
+
+  it('is true only when status is connected and publicKey is set', () => {
+    useWalletStore.setState({ status: 'connected', publicKey: 'GABC' });
+    expect(selectIsWalletConnected(useWalletStore.getState())).toBe(true);
+
+    useWalletStore.setState({ status: 'connecting', publicKey: 'GABC' });
+    expect(selectIsWalletConnected(useWalletStore.getState())).toBe(false);
+
+    useWalletStore.setState({ status: 'connected', publicKey: null });
+    expect(selectIsWalletConnected(useWalletStore.getState())).toBe(false);
+  });
+});
+
+describe('useWalletStore', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    clearAuth.mockClear();
+    setJwt.mockClear();
+    resetWalletState();
+  });
+
+  it('disconnect clears wallet and calls clearAuth', () => {
+    useWalletStore.setState({
+      status: 'connected',
+      publicKey: 'GKEY',
+      network: 'TESTNET',
+      balance: '1.00 XLM',
+    });
+
+    useWalletStore.getState().disconnect();
+
+    const s = useWalletStore.getState();
+    expect(s.status).toBe('idle');
+    expect(s.publicKey).toBeNull();
+    expect(clearAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('clearError removes error fields', () => {
+    useWalletStore.setState({
+      status: 'error',
+      errorMessage: 'oops',
+      errorCode: 'UNKNOWN',
+    });
+    useWalletStore.getState().clearError();
+    expect(useWalletStore.getState().errorMessage).toBeNull();
+    expect(useWalletStore.getState().errorCode).toBeNull();
+  });
+
+  it('checkConnection sets idle when Freighter is not connected', async () => {
+    vi.mocked(isConnected).mockResolvedValue({ isConnected: false });
+
+    await useWalletStore.getState().checkConnection();
+
+    const s = useWalletStore.getState();
+    expect(s.status).toBe('idle');
+    expect(s.publicKey).toBeNull();
+    expect(isConnected).toHaveBeenCalled();
+  });
+
+  it('checkConnection restores connected state with address and TESTNET', async () => {
+    vi.mocked(isConnected).mockResolvedValue({ isConnected: true });
+    vi.mocked(getAddress).mockResolvedValue({ address: 'GADDR', error: undefined });
+    vi.mocked(getNetwork).mockResolvedValue({
+      network: 'TESTNET',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      error: undefined,
+    } as Awaited<ReturnType<typeof getNetwork>>);
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        balances: [{ asset_type: 'native', balance: '10.5' }],
+      }),
+    }) as unknown as typeof fetch;
+
+    await useWalletStore.getState().checkConnection();
+
+    const s = useWalletStore.getState();
+    expect(s.status).toBe('connected');
+    expect(s.publicKey).toBe('GADDR');
+    expect(s.networkMismatch).toBe(false);
+    expect(s.balance).toBe('10.50 XLM');
+  });
+
+  it('dedupes concurrent checkConnection into one Freighter round-trip', async () => {
+    let resolveConnected!: (v: { isConnected: boolean }) => void;
+    const connectedPromise = new Promise<{ isConnected: boolean }>((res) => {
+      resolveConnected = res;
+    });
+
+    vi.mocked(isConnected).mockReturnValue(connectedPromise as never);
+    vi.mocked(getAddress).mockResolvedValue({ address: 'G1', error: undefined });
+    vi.mocked(getNetwork).mockResolvedValue({
+      network: 'TESTNET',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      error: undefined,
+    } as Awaited<ReturnType<typeof getNetwork>>);
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        balances: [{ asset_type: 'native', balance: '1' }],
+      }),
+    }) as unknown as typeof fetch;
+
+    const p1 = useWalletStore.getState().checkConnection();
+    const p2 = useWalletStore.getState().checkConnection();
+    resolveConnected({ isConnected: true });
+    await Promise.all([p1, p2]);
+
+    expect(isConnected).toHaveBeenCalledTimes(1);
+    expect(useWalletStore.getState().publicKey).toBe('G1');
+  });
+
+  it('connect sets error when Freighter never becomes available', async () => {
+    vi.mocked(isConnected).mockResolvedValue({ isConnected: false });
+
+    await useWalletStore.getState().connect();
+
+    const s = useWalletStore.getState();
+    expect(s.status).toBe('error');
+    expect(s.errorCode).toBe('FREIGHTER_UNAVAILABLE');
+    expect(s.publicKey).toBeNull();
+  });
+
+  it('connect reaches connected and authenticates when APIs succeed', async () => {
+    vi.mocked(isConnected).mockResolvedValue({ isConnected: true });
+    vi.mocked(requestAccess).mockResolvedValue({
+      address: 'GSIGNER',
+      error: undefined,
+    });
+    vi.mocked(getNetwork).mockResolvedValue({
+      network: 'TESTNET',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      error: undefined,
+    } as Awaited<ReturnType<typeof getNetwork>>);
+    vi.mocked(signMessage).mockResolvedValue({
+      signedMessage: 'sig',
+      signerAddress: 'GSIGNER',
+      error: undefined,
+    } as Awaited<ReturnType<typeof signMessage>>);
+
+    const fetchMock = vi.fn((url: string) => {
+      if (url.includes('horizon-testnet')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            balances: [{ asset_type: 'native', balance: '2' }],
+          }),
+        });
+      }
+      if (url.includes('/api/auth/challenge')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ challenge: 'challenge-bytes' }),
+        });
+      }
+      if (url.includes('/api/auth/connect')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ token: 'jwt-1' }),
+        });
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`));
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await useWalletStore.getState().connect();
+
+    const s = useWalletStore.getState();
+    expect(s.status).toBe('connected');
+    expect(s.publicKey).toBe('GSIGNER');
+    expect(setJwt).toHaveBeenCalledWith('jwt-1');
+    expect(s.errorCode).not.toBe('AUTH_FAILED');
+  });
+
+  it('connect keeps wallet connected but sets AUTH_FAILED when backend rejects', async () => {
+    vi.mocked(isConnected).mockResolvedValue({ isConnected: true });
+    vi.mocked(requestAccess).mockResolvedValue({
+      address: 'GSIGNER',
+      error: undefined,
+    });
+    vi.mocked(getNetwork).mockResolvedValue({
+      network: 'TESTNET',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      error: undefined,
+    } as Awaited<ReturnType<typeof getNetwork>>);
+    vi.mocked(signMessage).mockResolvedValue({
+      signedMessage: 'sig',
+      signerAddress: 'GSIGNER',
+      error: undefined,
+    } as Awaited<ReturnType<typeof signMessage>>);
+
+    const fetchMock = vi.fn((url: string) => {
+      if (url.includes('horizon-testnet')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            balances: [{ asset_type: 'native', balance: '2' }],
+          }),
+        });
+      }
+      if (url.includes('/api/auth/challenge')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ challenge: 'challenge-bytes' }),
+        });
+      }
+      if (url.includes('/api/auth/connect')) {
+        return Promise.resolve({ ok: false, status: 401 });
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`));
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await useWalletStore.getState().connect();
+
+    const s = useWalletStore.getState();
+    expect(s.status).toBe('connected');
+    expect(s.publicKey).toBe('GSIGNER');
+    expect(clearAuth).toHaveBeenCalled();
+    expect(s.errorCode).toBe('AUTH_FAILED');
+    expect(s.errorMessage).toMatch(/sign-in/i);
+  });
+});

--- a/src/store/useWalletStore.ts
+++ b/src/store/useWalletStore.ts
@@ -11,26 +11,177 @@ import { useAuthStore } from './useAuthStore';
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 
+/** Single source of truth for wallet UI + lifecycle (issue #71). */
+export type WalletStatus = 'idle' | 'checking' | 'connecting' | 'connected' | 'error';
+
+export type WalletErrorCode =
+  | 'FREIGHTER_UNAVAILABLE'
+  | 'ACCESS_DENIED'
+  | 'TIMEOUT'
+  | 'BALANCE_FAILED'
+  | 'NETWORK_MISMATCH'
+  | 'AUTH_FAILED'
+  | 'UNKNOWN';
+
 interface WalletState {
+  status: WalletStatus;
   publicKey: string | null;
   network: string | null;
   balance: string | null;
-  isConnecting: boolean;
+  /** Last user-visible error (cleared on successful connect/check). */
+  errorMessage: string | null;
+  errorCode: WalletErrorCode | null;
+  /** True when Freighter reports a network other than TESTNET (still connected). */
+  networkMismatch: boolean;
   connect: () => Promise<void>;
   disconnect: () => void;
   checkConnection: () => Promise<void>;
+  clearError: () => void;
 }
 
-export const useWalletStore = create<WalletState>((set) => ({
+/** Dedupe concurrent checkConnection calls (remount / multiple headers). */
+let checkConnectionInFlight: Promise<void> | null = null;
+
+function mapConnectError(err: unknown): { message: string; code: WalletErrorCode } {
+  const msg = err instanceof Error ? err.message : String(err);
+  const lower = msg.toLowerCase();
+  if (lower.includes('denied') || lower.includes('rejected') || lower.includes('user denied')) {
+    return { message: 'Wallet access was denied. Click Connect and approve in Freighter.', code: 'ACCESS_DENIED' };
+  }
+  if (lower.includes('timeout') || lower.includes('timed out')) {
+    return { message: 'Connection timed out. Check Freighter and try again.', code: 'TIMEOUT' };
+  }
+  return { message: 'Could not connect wallet. Try again or reinstall Freighter.', code: 'UNKNOWN' };
+}
+
+export const selectIsWalletConnected = (s: WalletState): boolean =>
+  s.status === 'connected' && Boolean(s.publicKey);
+
+export const useWalletStore = create<WalletState>((set, get) => ({
+  status: 'idle',
   publicKey: null,
   network: null,
   balance: null,
-  isConnecting: false,
+  errorMessage: null,
+  errorCode: null,
+  networkMismatch: false,
+
+  clearError: () => set({ errorMessage: null, errorCode: null }),
+
+  disconnect: () => {
+    set({
+      status: 'idle',
+      publicKey: null,
+      network: null,
+      balance: null,
+      errorMessage: null,
+      errorCode: null,
+      networkMismatch: false,
+    });
+    useAuthStore.getState().clearAuth();
+    toast.success('Wallet disconnected');
+  },
+
+  checkConnection: async () => {
+    if (checkConnectionInFlight) {
+      return checkConnectionInFlight;
+    }
+
+    checkConnectionInFlight = (async () => {
+      const prev = get();
+      if (prev.status === 'connecting') return;
+
+      set({ status: 'checking', errorMessage: null, errorCode: null });
+
+      try {
+        const { isConnected: freighterConnected } = await isConnected();
+        if (!freighterConnected) {
+          set({
+            status: 'idle',
+            publicKey: null,
+            network: null,
+            balance: null,
+            networkMismatch: false,
+          });
+          return;
+        }
+
+        const { address } = await getAddress();
+        if (!address) {
+          set({
+            status: 'idle',
+            publicKey: null,
+            network: null,
+            balance: null,
+            networkMismatch: false,
+          });
+          return;
+        }
+
+        const { network } = await getNetwork();
+        const net = (network as string | null) || null;
+        const networkMismatch = net !== 'TESTNET';
+
+        let formattedBalance: string | null = null;
+        try {
+          const response = await fetch(`https://horizon-testnet.stellar.org/accounts/${address}`);
+          if (response.status === 404) {
+            formattedBalance = '0.00 XLM';
+          } else if (!response.ok) {
+            throw new Error('Fetch failed');
+          } else {
+            const data = await response.json();
+            const balances = data.balances as Array<{ asset_type: string; balance: string }>;
+            const nativeBalance = balances.find((b) => b.asset_type === 'native');
+            formattedBalance = nativeBalance
+              ? `${parseFloat(nativeBalance.balance).toFixed(2)} XLM`
+              : '0.00 XLM';
+          }
+        } catch {
+          formattedBalance = null;
+          toast.error('Could not load balance. You can still use the app; try reconnecting if needed.');
+        }
+
+        set({
+          status: 'connected',
+          publicKey: address,
+          network: net,
+          balance: formattedBalance,
+          networkMismatch,
+          errorMessage: null,
+          errorCode: null,
+        });
+
+        if (networkMismatch) {
+          toast.error('Please switch to Stellar Testnet in Freighter for full compatibility.');
+        }
+      } catch {
+        set({
+          status: 'idle',
+          publicKey: null,
+          network: null,
+          balance: null,
+          networkMismatch: false,
+        });
+      } finally {
+        checkConnectionInFlight = null;
+      }
+    })();
+
+    return checkConnectionInFlight;
+  },
 
   connect: async () => {
-    try {
-      set({ isConnecting: true });
+    if (get().status === 'connecting') return;
 
+    set({
+      status: 'connecting',
+      errorMessage: null,
+      errorCode: null,
+      networkMismatch: false,
+    });
+
+    try {
       let connected = false;
       for (let i = 0; i < 5; i++) {
         const { isConnected: isFreighterConnected } = await isConnected();
@@ -38,39 +189,38 @@ export const useWalletStore = create<WalletState>((set) => ({
           connected = true;
           break;
         }
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await new Promise((resolve) => setTimeout(resolve, 100));
       }
 
       if (!connected) {
-        toast.error('Freighter wallet not installed!');
-        set({ isConnecting: false });
+        set({
+          status: 'error',
+          errorMessage: 'Freighter is not installed or not unlocked. Install Freighter and try again.',
+          errorCode: 'FREIGHTER_UNAVAILABLE',
+        });
+        toast.error('Freighter wallet not available');
         return;
       }
 
-      const timeoutPromise = new Promise<{ address: string; error?: string }>((_, reject) => {
-        setTimeout(() => reject(new Error("Connection timed out")), 30000); // 30 seconds timeout
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('TIMEOUT')), 30000);
       });
 
-      const { address, error } = await Promise.race([
-        requestAccess(),
-        timeoutPromise
-      ]);
+      const accessResult = await Promise.race([requestAccess(), timeoutPromise]);
+      const { address, error } = accessResult;
 
       if (error) {
-        throw new Error(error.toString());
+        throw new Error(String(error));
       }
-
       if (!address) {
         throw new Error('User denied access');
       }
 
       const { network } = await getNetwork();
+      const net = (network as string | null) || null;
+      const networkMismatch = net !== 'TESTNET';
 
-      if (network !== 'TESTNET') {
-        toast.error('Please switch to Stellar Testnet in Freighter');
-      }
-
-      let formattedBalance = '0.00 XLM';
+      let formattedBalance: string | null = null;
       try {
         const response = await fetch(`https://horizon-testnet.stellar.org/accounts/${address}`);
         if (response.status === 404) {
@@ -79,31 +229,33 @@ export const useWalletStore = create<WalletState>((set) => ({
           throw new Error('Failed to fetch account data');
         } else {
           const data = await response.json();
-          const balances = data.balances;
-          const nativeBalance = balances.find((b: { asset_type: string; balance: string }) => b.asset_type === 'native');
-
-          if (nativeBalance) {
-            formattedBalance = `${parseFloat(nativeBalance.balance).toFixed(2)} XLM`;
-          }
+          const balances = data.balances as Array<{ asset_type: string; balance: string }>;
+          const nativeBalance = balances.find((b) => b.asset_type === 'native');
+          formattedBalance = nativeBalance
+            ? `${parseFloat(nativeBalance.balance).toFixed(2)} XLM`
+            : '0.00 XLM';
         }
-      } catch (err) {
-        console.error('Failed to fetch balance:', err);
-        toast.error("Failed to fetch wallet balance");
-
-        set({ isConnecting: false });
-        return;
+      } catch {
+        formattedBalance = null;
+        toast.error('Connected, but balance could not be loaded. Try again later.');
       }
 
       set({
         publicKey: address,
-        network: (network as string | null) || null,
+        network: net,
         balance: formattedBalance,
-        isConnecting: false,
+        status: 'connected',
+        networkMismatch,
+        errorMessage: null,
+        errorCode: null,
       });
 
       toast.success('Wallet connected!');
 
-      // Backend auth: challenge → sign → JWT
+      if (networkMismatch) {
+        toast.error('Please switch to Stellar Testnet in Freighter');
+      }
+
       try {
         const challengeRes = await fetch(`${API_BASE}/api/auth/challenge`, {
           method: 'POST',
@@ -117,9 +269,10 @@ export const useWalletStore = create<WalletState>((set) => ({
 
         const { signedMessage, error: signError } = await signMessage(challenge, {
           address,
-          networkPassphrase: network === 'TESTNET'
-            ? 'Test SDF Network ; September 2015'
-            : 'Public Global Stellar Network ; September 2015',
+          networkPassphrase:
+            network === 'TESTNET'
+              ? 'Test SDF Network ; September 2015'
+              : 'Public Global Stellar Network ; September 2015',
         });
 
         if (signError) throw new Error(signError.message ?? 'Failed to sign challenge');
@@ -142,62 +295,34 @@ export const useWalletStore = create<WalletState>((set) => ({
         toast.success('Authenticated with backend!');
       } catch (authError) {
         console.error('Backend auth error:', authError);
+        useAuthStore.getState().clearAuth();
+        set({
+          errorMessage:
+            'Wallet is connected, but sign-in to the server failed. Try Disconnect and Connect again.',
+          errorCode: 'AUTH_FAILED',
+        });
         toast.error('Wallet connected but backend auth failed');
       }
     } catch (error) {
       console.error('Connection error:', error);
-      toast.error('Failed to connect wallet');
-      set({ isConnecting: false });
+      const mapped = mapConnectError(error);
+      const code: WalletErrorCode =
+        error instanceof Error && error.message === 'TIMEOUT' ? 'TIMEOUT' : mapped.code;
+      const message =
+        error instanceof Error && error.message === 'TIMEOUT'
+          ? 'Connection timed out. Unlock Freighter and try again.'
+          : mapped.message;
+
+      set({
+        status: 'error',
+        publicKey: null,
+        network: null,
+        balance: null,
+        networkMismatch: false,
+        errorMessage: message,
+        errorCode: code,
+      });
+      toast.error(message);
     }
   },
-
-  disconnect: () => {
-    set({ publicKey: null, network: null, balance: null });
-    useAuthStore.getState().clearAuth();
-    toast.success('Wallet disconnected');
-  },
-
-  checkConnection: async () => {
-    try {
-      const { isConnected: connected } = await isConnected();
-      if (connected) {
-        // use getAddress to check if we still have access without prompting
-        const { address } = await getAddress();
-
-        if (address) {
-          const { network } = await getNetwork();
-
-          let formattedBalance = '0.00 XLM';
-          try {
-            const response = await fetch(`https://horizon-testnet.stellar.org/accounts/${address}`);
-            if (response.status === 404) {
-              formattedBalance = '0.00 XLM';
-            } else if (!response.ok) {
-              throw new Error("Fetch failed");
-            } else {
-              const data = await response.json();
-              const balances = data.balances;
-              const nativeBalance = balances.find((b: { asset_type: string; balance: string }) => b.asset_type === 'native');
-
-              if (nativeBalance) {
-                formattedBalance = `${parseFloat(nativeBalance.balance).toFixed(2)} XLM`;
-              }
-            }
-          } catch (err) {
-            console.error('Failed to check balance:', err);
-            toast.error("Failed to fetch wallet balance");
-            return;
-          }
-
-          set({
-            publicKey: address,
-            network: (network as string | null) || null,
-            balance: formattedBalance
-          });
-        }
-      }
-    } catch {
-      // ignore: silently skip if Freighter is not connected on mount
-    }
-  }
 }));


### PR DESCRIPTION
## Summary
Implements clearer wallet lifecycle and UI for issue #71.

## Changes
- **useWalletStore**: status machine (`idle` | `checking` | `connecting` | `connected` | `error`), deduped `checkConnection`, backend auth failure keeps wallet connected with `AUTH_FAILED` messaging, `selectIsWalletConnected`, `clearError`.
- **WalletConnect**: checking / error / connected states, retry, accessibility tweaks.
- **PredictionControls / PredictionCard**: separate `isSubmittingPrediction` from wallet `isConnecting`.
- **Dashboard**: real wallet connected + connecting state; `PredictionHistory` still keyed by `publicKey`.
- **Tests**: `useWalletStore.test.ts` for transitions, dedupe, connect/auth paths.

## Testing
`npm run test` (lint, build, vitest) passes.

Closes #71

Made with [Cursor](https://cursor.com)