### PR TITLE
feat(a11y): baseline pass for header, modals, learn (#73)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -107,6 +107,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -476,6 +477,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -499,6 +501,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2444,8 +2447,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2530,6 +2532,7 @@
       "integrity": "sha512-OowOUbD1lBCOFIPOZ8xnMIhgqA4sCutMiYOmPHL1PTLt5+y1XA+g2+yC9OOyz8p+deMZqPZLxfMjYIfrKsPeFg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2540,6 +2543,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2550,6 +2554,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2606,6 +2611,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2980,6 +2986,7 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -3016,6 +3023,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3290,6 +3298,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3591,7 +3600,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -3695,8 +3705,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3919,6 +3928,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4769,6 +4779,7 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -5193,7 +5204,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5536,6 +5546,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5597,7 +5608,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5613,7 +5623,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5671,6 +5680,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5680,6 +5690,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5709,8 +5720,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -6504,6 +6514,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6670,6 +6681,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6745,6 +6757,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -7082,6 +7095,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ function App() {
         <NewsRibbon onClose={() => setShowNewsRibbon(false)} />
       )}
       <main
+        id="main-content"
         className={`px-4 lg:px-14 min-h-screen bg-[#FAFAFA] dark:bg-gray-900 transition-[padding] ${showNewsRibbon ? "pt-32 lg:pt-44" : "pt-24 lg:pt-32"
           }`}
       >

--- a/src/components/EndRoundModal.tsx
+++ b/src/components/EndRoundModal.tsx
@@ -14,11 +14,16 @@ export default function EndRoundModal({ isOpen, onClose, result }: EndRoundModal
   const { isWin, amount, tip } = result;
 
   return (
-    <Dialog.Root open={isOpen} onOpenChange={onClose}>
+    <Dialog.Root
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-black/90 backdrop-blur-md animate-fade-in z-40" />
-        
-        <Dialog.Content className="fixed inset-0 z-50 flex items-center justify-center p-4 focus:outline-none">
+
+        <Dialog.Content className="fixed inset-0 z-50 flex items-center justify-center p-4 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent">
           <div className="w-full max-w-md animate-scale-in">
             <div className={`relative overflow-hidden rounded-2xl border ${
               isWin ? 'bg-emerald-50 border-emerald-100' : 'bg-rose-50 border-rose-100'
@@ -30,9 +35,12 @@ export default function EndRoundModal({ isOpen, onClose, result }: EndRoundModal
               </div>
 
               <div className="relative pt-12 px-8 pb-8 text-center">
-                <div className={`mx-auto w-24 h-24 rounded-full flex items-center justify-center text-5xl mb-6 border-4 border-white ${
-                  isWin ? 'bg-emerald-400 text-white' : 'bg-rose-400 text-white'
-                }`}>
+                <div
+                  className={`mx-auto w-24 h-24 rounded-full flex items-center justify-center text-5xl mb-6 border-4 border-white ${
+                    isWin ? 'bg-emerald-400 text-white' : 'bg-rose-400 text-white'
+                  }`}
+                  aria-hidden
+                >
                   {isWin ? '📈' : '📉'}
                 </div>
 
@@ -43,7 +51,7 @@ export default function EndRoundModal({ isOpen, onClose, result }: EndRoundModal
                 </Dialog.Title>
                 
                 <Dialog.Description className={`text-lg font-medium mb-8 ${
-                  isWin ? 'text-emerald-700/80' : 'text-rose-700/80'
+                  isWin ? 'text-emerald-800 dark:text-emerald-900' : 'text-rose-800 dark:text-rose-900'
                 }`}>
                   {isWin ? 'You made all the right moves.' : 'The market moved against you.'}
                 </Dialog.Description>
@@ -65,9 +73,12 @@ export default function EndRoundModal({ isOpen, onClose, result }: EndRoundModal
                     : 'bg-rose-100/50 border-rose-200'
                 }`}>
                   <div className="flex gap-4">
-                    <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
-                      isWin ? 'bg-emerald-200 text-emerald-700' : 'bg-rose-200 text-rose-700'
-                    }`}>
+                    <div
+                      className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
+                        isWin ? 'bg-emerald-200 text-emerald-800' : 'bg-rose-200 text-rose-800'
+                      }`}
+                      aria-hidden
+                    >
                       💡
                     </div>
                     <div>
@@ -86,11 +97,14 @@ export default function EndRoundModal({ isOpen, onClose, result }: EndRoundModal
                 </div>
 
                 <Dialog.Close asChild>
-                  <button className={`w-full py-4 rounded-xl font-bold text-lg active:scale-95 transition-all outline-none focus:ring-4 ${
-                    isWin 
-                      ? 'bg-emerald-600 hover:bg-emerald-500 text-white focus:ring-emerald-200' 
-                      : 'bg-rose-600 hover:bg-rose-500 text-white focus:ring-rose-200'
-                  }`}>
+                  <button
+                    type="button"
+                    className={`w-full py-4 rounded-xl font-bold text-lg active:scale-95 transition-all outline-none focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-offset-2 ${
+                      isWin
+                        ? 'bg-emerald-600 hover:bg-emerald-500 text-white focus-visible:ring-emerald-300 focus-visible:ring-offset-emerald-50'
+                        : 'bg-rose-600 hover:bg-rose-500 text-white focus-visible:ring-rose-300 focus-visible:ring-offset-rose-50'
+                    }`}
+                  >
                     Continue to Next Round
                   </button>
                 </Dialog.Close>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { NavLink } from "react-router-dom";
+import { NavLink, Link } from "react-router-dom";
 import { useTheme } from "next-themes";
 import WalletConnect from "./WalletConnect";
 import NotificationsBell from "./NotificationsBell";
@@ -31,40 +31,51 @@ const Header = () => {
     { name: "Pools", route: "/pools" },
   ];
 
+  const navLinkClass = ({ isActive }: { isActive: boolean }) =>
+    `font-medium lg:text-xl rounded-lg py-1 px-3 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900 ${
+      isActive
+        ? "bg-[#2C4BFD] text-white"
+        : "text-[#9B9B9B] dark:text-gray-400 hover:bg-[#2C4BFD] hover:text-white"
+    }`;
+
+  const themeToggleLabel = isDark ? "Switch to light mode" : "Switch to dark mode";
+
   return (
     <header className="w-full bg-white dark:bg-gray-900 fixed top-0 left-0 z-20 border-b border-gray-100 dark:border-gray-800 transition-colors">
-      <nav className="w-full h-20 lg:h-28 flex items-center justify-between px-4 lg:px-10">
-        <div className="flex items-center justify-start gap-5 md:gap-2 lg:gap-4">
-          <img src={Logo} alt="logo" className="h-8 lg:h-10" />
-          <p className="text-2xl text-[#292D32] dark:text-gray-100 font-bold md:text-lg lg:text-2xl transition-colors">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-lg focus:bg-[#2C4BFD] focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-white focus:shadow-lg"
+      >
+        Skip to main content
+      </a>
+      <nav className="w-full h-20 lg:h-28 flex items-center justify-between px-4 lg:px-10" aria-label="Primary">
+        <Link
+          to="/"
+          className="flex items-center justify-start gap-5 md:gap-2 lg:gap-4 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
+          aria-label="Xelma home"
+        >
+          <img src={Logo} alt="" className="h-8 lg:h-10" />
+          <span className="text-2xl text-[#292D32] dark:text-gray-100 font-bold md:text-lg lg:text-2xl transition-colors">
             Xelma
-          </p>
-        </div>
+          </span>
+        </Link>
 
         <ul className="hidden md:flex items-center justify-center gap-6 lg:gap-10">
           {routes.map(({ name, route }) => (
-            <NavLink
-              key={name}
-              to={route}
-              end
-              className={({ isActive }) =>
-                `font-medium lg:text-xl rounded-lg py-1 px-3 transition-colors ${
-                  isActive
-                    ? "bg-[#2C4BFD] text-white"
-                    : "text-[#9B9B9B] dark:text-gray-400 hover:bg-[#2C4BFD] hover:text-white"
-                }`
-              }
-            >
-              {name}
-            </NavLink>
+            <li key={name}>
+              <NavLink to={route} end className={navLinkClass}>
+                {name}
+              </NavLink>
+            </li>
           ))}
         </ul>
 
         <div className="hidden md:flex items-center gap-3.5">
           <button
+            type="button"
             onClick={toggleTheme}
-            aria-label="Toggle theme"
-            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            aria-label={themeToggleLabel}
+            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
           >
             {isDark ? (
               <svg
@@ -72,6 +83,7 @@ const Header = () => {
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
+                aria-hidden
               >
                 <path
                   strokeLinecap="round"
@@ -86,6 +98,7 @@ const Header = () => {
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
+                aria-hidden
               >
                 <path
                   strokeLinecap="round"
@@ -102,9 +115,10 @@ const Header = () => {
 
         <div className="md:hidden flex items-center gap-2">
           <button
+            type="button"
             onClick={toggleTheme}
-            aria-label="Toggle theme"
-            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            aria-label={themeToggleLabel}
+            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
           >
             {isDark ? (
               <svg
@@ -112,6 +126,7 @@ const Header = () => {
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
+                aria-hidden
               >
                 <path
                   strokeLinecap="round"
@@ -126,6 +141,7 @@ const Header = () => {
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
+                aria-hidden
               >
                 <path
                   strokeLinecap="round"
@@ -136,49 +152,62 @@ const Header = () => {
               </svg>
             )}
           </button>
-          <div
-            onClick={() => setOpen(!open)}
-            aria-label="Toggle menu"
-            className="relative w-8 h-8 flex items-center justify-center"
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            aria-expanded={open}
+            aria-controls="mobile-primary-nav"
+            aria-label={open ? "Close menu" : "Open menu"}
+            className="relative h-10 w-10 flex items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
           >
+            <span className="sr-only">{open ? "Close navigation menu" : "Open navigation menu"}</span>
             <span
               className={`absolute h-0.5 w-6 bg-gray-800 dark:bg-gray-200 transition-transform duration-300 ${
                 open ? "rotate-45" : "-translate-y-2"
               }`}
+              aria-hidden
             />
             <span
               className={`absolute h-0.5 w-6 bg-gray-800 dark:bg-gray-200 transition-opacity duration-300 ${
                 open ? "opacity-0" : "opacity-100"
               }`}
+              aria-hidden
             />
             <span
               className={`absolute h-0.5 w-6 bg-gray-800 dark:bg-gray-200 transition-transform duration-300 ${
                 open ? "-rotate-45" : "translate-y-2"
               }`}
+              aria-hidden
             />
-          </div>
+          </button>
         </div>
       </nav>
 
       {open && (
-        <div className="md:hidden bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 px-4 pb-4 transition-colors">
+        <div
+          id="mobile-primary-nav"
+          className="md:hidden bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 px-4 pb-4 transition-colors"
+          role="region"
+          aria-label="Mobile navigation"
+        >
           <ul className="flex flex-col gap-2 pt-4">
             {routes.map(({ name, route }) => (
-              <NavLink
-                key={name}
-                to={route}
-                end
-                onClick={() => setOpen(false)}
-                className={({ isActive }) =>
-                  `text-lg font-medium py-2 px-3 rounded-lg transition-colors ${
-                    isActive
-                      ? "bg-[#2C4BFD] text-white"
-                      : "text-[#4D4D4D] dark:text-gray-300 hover:bg-[#2C4BFD] hover:text-white"
-                  }`
-                }
-              >
-                {name}
-              </NavLink>
+              <li key={name}>
+                <NavLink
+                  to={route}
+                  end
+                  onClick={() => setOpen(false)}
+                  className={({ isActive }) =>
+                    `block text-lg font-medium py-2 px-3 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900 ${
+                      isActive
+                        ? "bg-[#2C4BFD] text-white"
+                        : "text-[#4D4D4D] dark:text-gray-300 hover:bg-[#2C4BFD] hover:text-white"
+                    }`
+                  }
+                >
+                  {name}
+                </NavLink>
+              </li>
             ))}
           </ul>
 

--- a/src/components/NotificationsBell.tsx
+++ b/src/components/NotificationsBell.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useId, useRef, useState } from "react";
 import { Bell } from "./icons";
 import { useNotificationsStore } from "../store/useNotificationsStore";
 import type { NotificationEventPayload } from "../types/notification";
@@ -12,6 +12,7 @@ const NotificationsBell: React.FC = () => {
   // (we still subscribe to `unread` below for render updates)
   const addNotification = useNotificationsStore((s) => s.addNotification);
   const [open, setOpen] = useState(false);
+  const panelId = useId();
   const joinedRef = useRef(false);
 
   useEffect(() => {
@@ -41,22 +42,42 @@ const NotificationsBell: React.FC = () => {
     };
   }, [addNotification]);
 
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const bellLabel =
+    unread > 0 ? `Open notifications, ${unread} unread` : "Open notifications";
 
   return (
     <div className="relative">
       <button
-        className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors relative"
-        aria-label="Open notifications"
+        type="button"
+        className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
+        aria-label={bellLabel}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        aria-controls={panelId}
         onClick={() => setOpen((v) => !v)}
       >
-        <Bell className="w-5 h-5 text-gray-700 dark:text-gray-200" />
+        <Bell className="w-5 h-5 text-gray-700 dark:text-gray-200" aria-hidden />
         {unread > 0 && (
-          <span className="absolute -top-1 -right-1 bg-red-500 text-white rounded-full text-xs leading-none px-1.5">
+          <span className="absolute -top-1 -right-1 bg-red-500 text-white rounded-full text-xs leading-none px-1.5" aria-hidden>
             {unread}
           </span>
         )}
       </button>
-      {open && <NotificationsPanel onClose={() => setOpen(false)} />}
+      {open && (
+        <NotificationsPanel id={panelId} onClose={() => setOpen(false)} />
+      )}
     </div>
   );
 };

--- a/src/components/NotificationsPanel.tsx
+++ b/src/components/NotificationsPanel.tsx
@@ -3,7 +3,11 @@ import { useNotificationsStore } from '../store/useNotificationsStore';
 import { Clock, Check } from './icons';
 import { LoadingState, ErrorState, EmptyState } from './ui/StatusStates';
 
-const NotificationsPanel: React.FC<{ onClose: () => void }> = ({ onClose }) => {
+const NotificationsPanel: React.FC<{ id: string; onClose: () => void }> = ({
+  id,
+  onClose,
+}) => {
+  const titleId = `${id}-title`;
   const list = useNotificationsStore((s) => s.list);
   const loadingList = useNotificationsStore((s) => s.loadingList);
   const errorList = useNotificationsStore((s) => s.errorList);
@@ -19,10 +23,23 @@ const NotificationsPanel: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   };
 
   return (
-    <div className="absolute right-0 mt-2 w-96 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg shadow-lg z-50">
-      <div className="p-4 border-b border-gray-100 dark:border-gray-800 flex items-center justify-between">
-        <h3 className="text-lg font-medium">Notifications</h3>
-        <button onClick={onClose} aria-label="Close" className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800">
+    <div
+      id={id}
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby={titleId}
+      className="absolute right-0 mt-2 w-96 max-w-[calc(100vw-2rem)] bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg shadow-lg z-50"
+    >
+      <div className="p-4 border-b border-gray-100 dark:border-gray-800 flex items-center justify-between gap-2">
+        <h2 id={titleId} className="text-lg font-medium text-gray-900 dark:text-gray-100">
+          Notifications
+        </h2>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close notifications"
+          className="shrink-0 rounded-lg px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
+        >
           Close
         </button>
       </div>
@@ -51,15 +68,25 @@ const NotificationsPanel: React.FC<{ onClose: () => void }> = ({ onClose }) => {
         {!loadingList && !errorList && list.length > 0 && (
           <div>
             {list.map((n) => (
-              <div key={n.id} className={`p-4 border-b border-gray-100 dark:border-gray-800 flex items-start justify-between ${n.read ? 'opacity-60' : ''}`}>
-                <div>
-                  <div className="font-medium">{n.title}</div>
-                  <div className="text-sm text-gray-500">{n.message}</div>
-                  <div className="text-xs text-gray-400 mt-1">{new Date(n.createdAt).toLocaleString()}</div>
+              <div
+                key={n.id}
+                className={`p-4 border-b border-gray-100 dark:border-gray-800 flex items-start justify-between gap-3 ${n.read ? 'opacity-60' : ''}`}
+              >
+                <div className="min-w-0">
+                  <div className="font-medium text-gray-900 dark:text-gray-100">{n.title}</div>
+                  <div className="text-sm text-gray-600 dark:text-gray-400">{n.message}</div>
+                  <div className="text-xs text-gray-500 dark:text-gray-500 mt-1">
+                    {new Date(n.createdAt).toLocaleString()}
+                  </div>
                 </div>
                 {!n.read && (
-                  <button aria-label="Mark as read" onClick={() => markAsRead(n.id)} className="ml-4 p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800">
-                    <Check className="w-4 h-4" />
+                  <button
+                    type="button"
+                    aria-label={`Mark notification “${n.title}” as read`}
+                    onClick={() => markAsRead(n.id)}
+                    className="shrink-0 p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
+                  >
+                    <Check className="w-4 h-4" aria-hidden />
                   </button>
                 )}
               </div>

--- a/src/components/PredictionCard.tsx
+++ b/src/components/PredictionCard.tsx
@@ -5,6 +5,7 @@ interface PredictionCardProps {
   isWalletConnected?: boolean;
   isRoundActive?: boolean;
   isConnecting?: boolean;
+  isSubmittingPrediction?: boolean;
   onPrediction?: (prediction: PredictionData) => void;
 }
 
@@ -12,10 +13,12 @@ const PredictionCard = ({
   isWalletConnected = false,
   isRoundActive = true,
   isConnecting = false,
+  isSubmittingPrediction = false,
   onPrediction,
 }: PredictionCardProps) => {
 
-  const isDisabled = !isWalletConnected || !isRoundActive || isConnecting;
+  const isDisabled =
+    !isWalletConnected || !isRoundActive || isConnecting || isSubmittingPrediction;
 
   return (
     <div
@@ -26,6 +29,7 @@ const PredictionCard = ({
         isWalletConnected={isWalletConnected}
         isRoundActive={isRoundActive}
         isConnecting={isConnecting}
+        isSubmittingPrediction={isSubmittingPrediction}
         onPrediction={onPrediction}
       />
 

--- a/src/components/PredictionControls.tsx
+++ b/src/components/PredictionControls.tsx
@@ -15,7 +15,10 @@ export interface PredictionData {
 export interface PredictionControlsProps {
   isWalletConnected?: boolean;
   isRoundActive?: boolean;
+  /** Wallet/session connecting (e.g. Freighter flow). */
   isConnecting?: boolean;
+  /** Prediction submit in flight (distinct from wallet connecting). */
+  isSubmittingPrediction?: boolean;
   onPrediction?: (prediction: PredictionData) => void;
 }
 
@@ -37,6 +40,7 @@ export function PredictionControls({
   isWalletConnected = false,
   isRoundActive = true,
   isConnecting = false,
+  isSubmittingPrediction = false,
   onPrediction,
 }: PredictionControlsProps) {
   const [stake, setStake] = useState("");
@@ -46,7 +50,8 @@ export function PredictionControls({
   const [selectedDirection, setSelectedDirection] = useState<"UP" | "DOWN" | null>(null);
   const [touchedExactPrice, setTouchedExactPrice] = useState(false);
 
-  const isDisabled = !isWalletConnected || !isRoundActive || isConnecting;
+  const isDisabled =
+    !isWalletConnected || !isRoundActive || isConnecting || isSubmittingPrediction;
 
   const validateExactPriceField = useCallback(() => {
     if (!isLegend) return;
@@ -108,7 +113,12 @@ export function PredictionControls({
 
       {isConnecting && (
         <p className="prediction-card__connecting" role="status">
-          Connecting...
+          Connecting wallet...
+        </p>
+      )}
+      {isSubmittingPrediction && !isConnecting && (
+        <p className="prediction-card__connecting" role="status">
+          Submitting prediction...
         </p>
       )}
 
@@ -222,7 +232,7 @@ export function PredictionControls({
         </div>
       )}
 
-      {isDisabled && !isConnecting && (
+      {isDisabled && !isConnecting && !isSubmittingPrediction && (
         <div className="prediction-card__disabled-message">
           {!isWalletConnected && <p>Connect your wallet to make predictions</p>}
           {isWalletConnected && !isRoundActive && <p>This round is not active</p>}

--- a/src/components/ProfileSettingsModal.tsx
+++ b/src/components/ProfileSettingsModal.tsx
@@ -197,12 +197,15 @@ function ProfileSettingsForm({
   return (
     <div className="fixed inset-0 z-[9999]" onMouseDown={handleBackdropMouseDown}>
       {/* overlay */}
-      <div className="absolute inset-0 bg-black/50" />
+      <div className="absolute inset-0 bg-black/50" aria-hidden />
 
       {/* centered modal */}
       <div className="absolute inset-0 flex items-center justify-center p-4 sm:p-6">
         <div
           ref={modalRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="profile-settings-title"
           className={cx(
             "relative w-full max-w-3xl",
             "rounded-2xl bg-white dark:bg-gray-900",
@@ -212,22 +215,23 @@ function ProfileSettingsForm({
           )}
         >
           <div className="relative px-6 sm:px-8 pt-6 pb-4 border-b border-gray-100 dark:border-gray-800">
-            <h2 className="text-sm font-bold tracking-wide text-gray-800 dark:text-gray-100">
+            <h2
+              id="profile-settings-title"
+              className="text-sm font-bold tracking-wide text-gray-800 dark:text-gray-100 pr-12"
+            >
               PROFILE SETTINGS
             </h2>
 
-            <div
-              role="button"
-              tabIndex={0}
-              aria-label="Close"
+            <button
+              type="button"
+              aria-label="Close profile settings"
               onClick={onClose}
-              onKeyDown={(e) => onEnterOrSpace(e, onClose)}
-              className="absolute right-4 top-4 sm:right-6 sm:top-5 flex h-9 w-9 cursor-pointer items-center justify-center rounded-full text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
+              className="absolute right-4 top-4 sm:right-6 sm:top-5 flex h-9 w-9 cursor-pointer items-center justify-center rounded-full text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
             >
-              <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">
+              <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M6 6l12 12M18 6L6 18" />
               </svg>
-            </div>
+            </button>
           </div>
 
           <div className="px-6 sm:px-8 py-6 overflow-y-auto max-h-[calc(85vh-72px)]">
@@ -249,24 +253,26 @@ function ProfileSettingsForm({
               </div>
 
               <label
-                role="button"
-                tabIndex={0}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    (e.currentTarget.querySelector("input") as HTMLInputElement | null)?.click();
-                  }
-                }}
-                className="inline-flex cursor-pointer select-none items-center justify-center rounded-xl bg-[#2C4BFD] px-7 py-3 text-sm font-semibold text-white hover:opacity-95"
+                htmlFor="profile-avatar-upload"
+                className="inline-flex cursor-pointer select-none items-center justify-center rounded-xl bg-[#2C4BFD] px-7 py-3 text-sm font-semibold text-white hover:opacity-95 focus-within:outline-none focus-within:ring-2 focus-within:ring-[#2C4BFD] focus-within:ring-offset-2 dark:focus-within:ring-offset-gray-900"
               >
                 UPLOAD
-                <input type="file" accept="image/*" className="sr-only" onChange={handleUploadChange} />
+                <input
+                  id="profile-avatar-upload"
+                  type="file"
+                  accept="image/*"
+                  className="sr-only"
+                  onChange={handleUploadChange}
+                />
               </label>
             </div>
 
             <div className="mt-7">
-              <p className="text-xs font-bold tracking-wide text-gray-600 dark:text-gray-300">NAME</p>
+              <label htmlFor="profile-display-name" className="text-xs font-bold tracking-wide text-gray-600 dark:text-gray-300 block">
+                NAME
+              </label>
               <input
+                id="profile-display-name"
                 ref={nameRef}
                 value={name}
                 onChange={(e) => {
@@ -277,17 +283,21 @@ function ProfileSettingsForm({
                   "mt-3 w-full rounded-2xl px-5 py-4 text-sm",
                   "bg-gray-50 border border-gray-200 text-gray-800",
                   "dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100",
-                  "focus:outline-none focus:ring-2 focus:ring-[#2C4BFD]/30 focus:border-[#2C4BFD]/40",
-                  errors.name && "border-red-500/60 focus:ring-red-500/30"
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD]/50 focus-visible:border-[#2C4BFD]/50",
+                  errors.name && "border-red-500/60 focus-visible:ring-red-500/40"
                 )}
                 placeholder="Your display name"
+                autoComplete="nickname"
               />
               {errors.name && <p className="mt-2 text-xs text-red-600 dark:text-red-400">{errors.name}</p>}
             </div>
 
             <div className="mt-7">
-              <p className="text-xs font-bold tracking-wide text-gray-600 dark:text-gray-300">BIO</p>
+              <label htmlFor="profile-bio" className="text-xs font-bold tracking-wide text-gray-600 dark:text-gray-300 block">
+                BIO
+              </label>
               <textarea
+                id="profile-bio"
                 value={bio}
                 onChange={(e) => {
                   setBio(e.target.value);
@@ -298,8 +308,8 @@ function ProfileSettingsForm({
                   "mt-3 w-full resize-none rounded-2xl px-5 py-4 text-sm",
                   "bg-gray-50 border border-gray-200 text-gray-800",
                   "dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100",
-                  "focus:outline-none focus:ring-2 focus:ring-[#2C4BFD]/30 focus:border-[#2C4BFD]/40",
-                  errors.bio && "border-red-500/60 focus:ring-red-500/30"
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD]/50 focus-visible:border-[#2C4BFD]/50",
+                  errors.bio && "border-red-500/60 focus-visible:ring-red-500/40"
                 )}
                 placeholder="Short description (max 100 chars)"
               />
@@ -313,20 +323,24 @@ function ProfileSettingsForm({
             </div>
 
             <div className="mt-7">
-              <p className="text-xs font-bold tracking-wide text-gray-600 dark:text-gray-300">LINKS</p>
+              <label htmlFor="profile-twitter-link" className="text-xs font-bold tracking-wide text-gray-600 dark:text-gray-300 block">
+                LINKS
+              </label>
               <div className="mt-3 flex items-center gap-3 rounded-2xl bg-gray-50 border border-gray-200 px-5 py-4 dark:bg-gray-800 dark:border-gray-700">
                 <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 text-gray-700 dark:text-gray-200" fill="currentColor">
                   <path d="M18.244 2H21l-6.52 7.46L22 22h-6.828l-5.35-6.92L3.78 22H1l7.02-8.04L2 2h6.999l4.84 6.29L18.244 2Zm-1.196 18h1.88L7.93 3.91H5.91L17.048 20Z" />
                 </svg>
 
                 <input
+                  id="profile-twitter-link"
                   value={twitterLink}
                   onChange={(e) => {
                     setTwitterLink(e.target.value);
                     if (errors.twitterLink) setErrors((p) => ({ ...p, twitterLink: undefined }));
                   }}
-                  className="w-full bg-transparent text-sm text-gray-800 placeholder:text-gray-400 focus:outline-none dark:text-gray-100 dark:placeholder:text-gray-500"
+                  className="w-full bg-transparent text-sm text-gray-800 placeholder:text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD]/40 rounded-md dark:text-gray-100 dark:placeholder:text-gray-500"
                   placeholder="https://x.com/your_handle"
+                  autoComplete="url"
                 />
               </div>
 
@@ -346,10 +360,12 @@ function ProfileSettingsForm({
                   role="switch"
                   tabIndex={0}
                   aria-checked={streamerMode}
+                  aria-label="Streamer mode"
                   onClick={() => setStreamerMode((v) => !v)}
                   onKeyDown={(e) => onEnterOrSpace(e, () => setStreamerMode((v) => !v))}
                   className={cx(
-                    "relative inline-flex h-7 w-12 items-center rounded-full cursor-pointer transition",
+                    "relative inline-flex h-7 w-12 items-center rounded-full cursor-pointer transition shrink-0",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800",
                     streamerMode ? "bg-[#2C4BFD]" : "bg-gray-300 dark:bg-gray-700"
                   )}
                 >
@@ -364,18 +380,18 @@ function ProfileSettingsForm({
             </div>
 
             <div className="mt-9 flex justify-end">
-              <div
-                role="button"
-                tabIndex={0}
+              <button
+                type="button"
                 onClick={() => { void handleSave(); }}
-                onKeyDown={(e) => onEnterOrSpace(e, () => { void handleSave(); })}
+                disabled={isSaving}
                 className={cx(
                   "rounded-2xl bg-[#2C4BFD] px-10 py-4 text-sm font-semibold text-white cursor-pointer hover:opacity-95",
-                  isSaving && "opacity-60 pointer-events-none"
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900",
+                  isSaving && "opacity-60 pointer-events-none cursor-not-allowed"
                 )}
               >
                 {isSaving ? "SAVING..." : "SAVE"}
-              </div>
+              </button>
             </div>
 
             <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
@@ -401,8 +417,8 @@ export default function ProfileSettingsModal({ onClose, initialValues }: Props) 
 
   if (!ready || isLoading) {
     const shell = (
-      <div className="fixed inset-0 z-[9999]">
-        <div className="absolute inset-0 bg-black/50" />
+      <div className="fixed inset-0 z-[9999]" role="dialog" aria-modal="true" aria-busy="true" aria-label="Profile settings">
+        <div className="absolute inset-0 bg-black/50" aria-hidden />
         <div className="absolute inset-0 flex items-center justify-center p-4 sm:p-6">
           <div
             className={cx(
@@ -410,10 +426,11 @@ export default function ProfileSettingsModal({ onClose, initialValues }: Props) 
               "rounded-2xl bg-white dark:bg-gray-900",
               "border border-gray-100 dark:border-gray-800",
               "shadow-2xl",
-              "flex items-center justify-center py-24"
+              "flex flex-col items-center justify-center gap-4 py-24"
             )}
           >
-            <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-[#2C4BFD]" />
+            <p className="sr-only">Loading profile settings</p>
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-[#2C4BFD]" aria-hidden />
           </div>
         </div>
       </div>

--- a/src/components/WalletConnect.tsx
+++ b/src/components/WalletConnect.tsx
@@ -4,6 +4,9 @@ import { useAuthStore } from '../store/useAuthStore';
 import { Loader2, AlertCircle, LogOut, Wallet, ShieldCheck, RefreshCw } from 'lucide-react';
 import clsx from 'clsx';
 
+const focusRing =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900';
+
 const WalletConnect = () => {
   const {
     publicKey,
@@ -28,10 +31,10 @@ const WalletConnect = () => {
 
   if (publicKey && status === 'connected') {
     return (
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-2 sm:gap-3">
         {networkMismatch && (
           <div
-            className="hidden md:flex items-center text-red-500 text-sm font-medium bg-red-50 dark:bg-red-900/20 px-2 py-1 rounded"
+            className="hidden md:flex items-center text-red-600 dark:text-red-400 text-sm font-medium bg-red-50 dark:bg-red-900/20 px-2 py-1 rounded"
             role="status"
           >
             <AlertCircle className="w-4 h-4 mr-1 shrink-0" aria-hidden />
@@ -40,31 +43,44 @@ const WalletConnect = () => {
         )}
 
         <div className="hidden md:flex items-center gap-2 px-3 py-1.5 bg-white dark:bg-gray-800 border border-[#BEC7FE] dark:border-gray-700 rounded-lg shadow-sm">
-          <span className="text-sm font-semibold text-[#4D4D4D] dark:text-gray-300">
-            {balance ?? '—'}
+          <span className="text-sm font-semibold text-gray-800 dark:text-gray-200">
+            {balance ? (
+              <>
+                <span className="sr-only">Balance: </span>
+                {balance}
+              </>
+            ) : (
+              <>
+                <span className="sr-only">Balance unavailable</span>
+                <span aria-hidden>—</span>
+              </>
+            )}
           </span>
         </div>
 
-        <div className="flex items-center gap-2 p-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg pr-3 relative group">
+        <div className="flex items-center gap-1 sm:gap-2 p-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg pr-2 sm:pr-3">
           <div
-            className="w-8 h-8 rounded-full bg-gradient-to-tr from-blue-500 to-purple-500 flex items-center justify-center text-white text-xs"
+            className="w-8 h-8 rounded-full bg-gradient-to-tr from-blue-500 to-purple-500 flex items-center justify-center text-white text-xs shrink-0"
             aria-hidden
           >
             <Wallet className="w-4 h-4" />
           </div>
-          <span className="text-sm font-medium text-gray-700 dark:text-gray-200">{shortAddress}</span>
+          <span className="text-sm font-medium text-gray-800 dark:text-gray-200 tabular-nums max-w-[7rem] sm:max-w-none truncate">
+            {shortAddress}
+          </span>
           {isAuthenticated && (
-            <ShieldCheck className="w-4 h-4 text-green-500" aria-label="Authenticated with backend" />
+            <ShieldCheck className="w-4 h-4 text-green-600 dark:text-green-400 shrink-0" aria-label="Signed in to server" />
           )}
-
           <button
             type="button"
             onClick={disconnect}
-            className="absolute top-full right-0 mt-2 w-full min-w-[120px] bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-lg shadow-lg py-2 px-3 flex items-center gap-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/10 opacity-0 invisible group-hover:opacity-100 group-hover:visible group-focus-within:opacity-100 group-focus-within:visible transition-all duration-200 z-50"
+            className={clsx(
+              'shrink-0 p-2 rounded-lg text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20',
+              focusRing
+            )}
             aria-label="Disconnect wallet"
           >
-            <LogOut className="w-4 h-4 shrink-0" aria-hidden />
-            <span className="text-sm">Disconnect</span>
+            <LogOut className="w-4 h-4" aria-hidden />
           </button>
         </div>
       </div>
@@ -74,7 +90,10 @@ const WalletConnect = () => {
   if (status === 'error' && errorMessage) {
     return (
       <div className="flex flex-col items-end gap-2 sm:flex-row sm:items-center sm:gap-3">
-        <p className="text-xs sm:text-sm text-red-600 dark:text-red-400 max-w-[220px] sm:max-w-xs text-right sm:text-left">
+        <p
+          className="text-xs sm:text-sm text-red-700 dark:text-red-300 max-w-[220px] sm:max-w-xs text-right sm:text-left"
+          role="alert"
+        >
           {errorMessage}
         </p>
         <div className="flex gap-2">
@@ -84,7 +103,10 @@ const WalletConnect = () => {
               clearError();
               void connect();
             }}
-            className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-semibold bg-[#2C4BFD] text-white hover:bg-[#1a3bf0]"
+            className={clsx(
+              'flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-semibold bg-[#2C4BFD] text-white hover:bg-[#1a3bf0]',
+              focusRing
+            )}
           >
             <RefreshCw className="w-4 h-4" aria-hidden />
             Retry
@@ -102,7 +124,8 @@ const WalletConnect = () => {
       className={clsx(
         'flex items-center gap-2 px-4 py-2 rounded-lg font-semibold transition-all duration-200',
         'bg-[#2C4BFD] hover:bg-[#1a3bf0] text-white shadow-lg shadow-blue-500/20',
-        'disabled:opacity-70 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2C4BFD]'
+        'disabled:opacity-70 disabled:cursor-not-allowed',
+        focusRing
       )}
       aria-busy={status === 'connecting' || status === 'checking'}
     >

--- a/src/components/WalletConnect.tsx
+++ b/src/components/WalletConnect.tsx
@@ -1,93 +1,129 @@
 import { useEffect } from 'react';
 import { useWalletStore } from '../store/useWalletStore';
 import { useAuthStore } from '../store/useAuthStore';
-import { Loader2, AlertCircle, LogOut, Wallet, ShieldCheck } from 'lucide-react';
+import { Loader2, AlertCircle, LogOut, Wallet, ShieldCheck, RefreshCw } from 'lucide-react';
 import clsx from 'clsx';
 
-
 const WalletConnect = () => {
-    const {
-        publicKey,
-        balance,
-        network,
-        isConnecting,
-        connect,
-        disconnect,
-        checkConnection
-    } = useWalletStore();
-    const { isAuthenticated } = useAuthStore();
+  const {
+    publicKey,
+    balance,
+    status,
+    errorMessage,
+    networkMismatch,
+    connect,
+    disconnect,
+    checkConnection,
+    clearError,
+  } = useWalletStore();
+  const { isAuthenticated } = useAuthStore();
 
-    useEffect(() => {
-        checkConnection();
-    }, [checkConnection]);
+  useEffect(() => {
+    void checkConnection();
+  }, [checkConnection]);
 
+  const shortAddress = publicKey
+    ? `${publicKey.slice(0, 4)}...${publicKey.slice(-4)}`
+    : '';
 
-
-    const shortAddress = publicKey
-        ? `${publicKey.slice(0, 4)}...${publicKey.slice(-4)}`
-        : '';
-
-    if (publicKey) {
-        return (
-            <div className="flex items-center gap-3">
-                {network !== 'TESTNET' && (
-                    <div className="hidden md:flex items-center text-red-500 text-sm font-medium bg-red-50 dark:bg-red-900/20 px-2 py-1 rounded">
-                        <AlertCircle className="w-4 h-4 mr-1" />
-                        Testnet Only
-                    </div>
-                )}
-
-                <div className="hidden md:flex items-center gap-2 px-3 py-1.5 bg-white dark:bg-gray-800 border border-[#BEC7FE] dark:border-gray-700 rounded-lg shadow-sm">
-                    <span className="text-sm font-semibold text-[#4D4D4D] dark:text-gray-300">
-                        {balance}
-                    </span>
-                </div>
-
-                <div className="flex items-center gap-2 p-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg pr-3 relative group">
-                    <div className="w-8 h-8 rounded-full bg-gradient-to-tr from-blue-500 to-purple-500 flex items-center justify-center text-white text-xs">
-                        <Wallet className="w-4 h-4" />
-                    </div>
-                    <span className="text-sm font-medium text-gray-700 dark:text-gray-200">
-                        {shortAddress}
-                    </span>
-                    {isAuthenticated && (
-                        <ShieldCheck className="w-4 h-4 text-green-500" aria-label="Authenticated with backend" />
-                    )}
-
-                    <button
-                        onClick={disconnect}
-                        className="absolute top-full right-0 mt-2 w-full min-w-[120px] bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-lg shadow-lg py-2 px-3 flex items-center gap-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/10 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
-                        <LogOut className="w-4 h-4" />
-                        <span className="text-sm cursor-pointer">Disconnect</span>
-                    </button>
-                </div>
-            </div>
-        );
-    }
-
+  if (publicKey && status === 'connected') {
     return (
-        <button
-            onClick={connect}
-            disabled={isConnecting}
-            className={clsx(
-                "flex items-center gap-2 px-4 py-2 rounded-lg font-semibold transition-all duration-200 cursor-pointer",
-                "bg-[#2C4BFD] hover:bg-[#1a3bf0] text-white shadow-lg shadow-blue-500/20",
-                "disabled:opacity-70 disabled:cursor-not-allowed"
-            )}
-        >
-            {isConnecting ? (
-                <>
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                    <span>Connecting...</span>
-                </>
-            ) : (
-                <>
-                    <Wallet className="w-4 h-4" />
-                    <span>Connect Wallet</span>
-                </>
-            )}
-        </button>
+      <div className="flex items-center gap-3">
+        {networkMismatch && (
+          <div
+            className="hidden md:flex items-center text-red-500 text-sm font-medium bg-red-50 dark:bg-red-900/20 px-2 py-1 rounded"
+            role="status"
+          >
+            <AlertCircle className="w-4 h-4 mr-1 shrink-0" aria-hidden />
+            Switch to Testnet in Freighter
+          </div>
+        )}
+
+        <div className="hidden md:flex items-center gap-2 px-3 py-1.5 bg-white dark:bg-gray-800 border border-[#BEC7FE] dark:border-gray-700 rounded-lg shadow-sm">
+          <span className="text-sm font-semibold text-[#4D4D4D] dark:text-gray-300">
+            {balance ?? '—'}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2 p-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg pr-3 relative group">
+          <div
+            className="w-8 h-8 rounded-full bg-gradient-to-tr from-blue-500 to-purple-500 flex items-center justify-center text-white text-xs"
+            aria-hidden
+          >
+            <Wallet className="w-4 h-4" />
+          </div>
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-200">{shortAddress}</span>
+          {isAuthenticated && (
+            <ShieldCheck className="w-4 h-4 text-green-500" aria-label="Authenticated with backend" />
+          )}
+
+          <button
+            type="button"
+            onClick={disconnect}
+            className="absolute top-full right-0 mt-2 w-full min-w-[120px] bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-lg shadow-lg py-2 px-3 flex items-center gap-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/10 opacity-0 invisible group-hover:opacity-100 group-hover:visible group-focus-within:opacity-100 group-focus-within:visible transition-all duration-200 z-50"
+            aria-label="Disconnect wallet"
+          >
+            <LogOut className="w-4 h-4 shrink-0" aria-hidden />
+            <span className="text-sm">Disconnect</span>
+          </button>
+        </div>
+      </div>
     );
+  }
+
+  if (status === 'error' && errorMessage) {
+    return (
+      <div className="flex flex-col items-end gap-2 sm:flex-row sm:items-center sm:gap-3">
+        <p className="text-xs sm:text-sm text-red-600 dark:text-red-400 max-w-[220px] sm:max-w-xs text-right sm:text-left">
+          {errorMessage}
+        </p>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              clearError();
+              void connect();
+            }}
+            className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-semibold bg-[#2C4BFD] text-white hover:bg-[#1a3bf0]"
+          >
+            <RefreshCw className="w-4 h-4" aria-hidden />
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => void connect()}
+      disabled={status === 'connecting' || status === 'checking'}
+      className={clsx(
+        'flex items-center gap-2 px-4 py-2 rounded-lg font-semibold transition-all duration-200',
+        'bg-[#2C4BFD] hover:bg-[#1a3bf0] text-white shadow-lg shadow-blue-500/20',
+        'disabled:opacity-70 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2C4BFD]'
+      )}
+      aria-busy={status === 'connecting' || status === 'checking'}
+    >
+      {status === 'connecting' ? (
+        <>
+          <Loader2 className="w-4 h-4 animate-spin" aria-hidden />
+          <span>Connecting…</span>
+        </>
+      ) : status === 'checking' ? (
+        <>
+          <Loader2 className="w-4 h-4 animate-spin" aria-hidden />
+          <span>Checking wallet…</span>
+        </>
+      ) : (
+        <>
+          <Wallet className="w-4 h-4" aria-hidden />
+          <span>Connect Wallet</span>
+        </>
+      )}
+    </button>
+  );
 };
 
 export default WalletConnect;

--- a/src/components/__tests__/Header.a11y.test.tsx
+++ b/src/components/__tests__/Header.a11y.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import Header from '../Header';
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ theme: 'light', setTheme: vi.fn() }),
+}));
+
+vi.mock('../WalletConnect', () => ({
+  default: () => <div data-testid="wallet-mock">Wallet</div>,
+}));
+
+vi.mock('../NotificationsBell', () => ({
+  default: () => <div data-testid="bell-mock">Bell</div>,
+}));
+
+vi.mock('../store/useProfileStore', () => ({
+  useProfileStore: (selector: (s: { profile: null }) => unknown) => selector({ profile: null }),
+}));
+
+function renderHeader() {
+  return render(
+    <MemoryRouter>
+      <Header />
+    </MemoryRouter>,
+  );
+}
+
+describe('Header accessibility', () => {
+  it('exposes a labeled primary navigation landmark', () => {
+    renderHeader();
+    expect(screen.getByRole('navigation', { name: 'Primary' })).toBeInTheDocument();
+  });
+
+  it('provides a skip link to main content', () => {
+    renderHeader();
+    const skip = screen.getByRole('link', { name: /skip to main content/i });
+    expect(skip).toHaveAttribute('href', '#main-content');
+  });
+
+  it('exposes the home control with an accessible name', () => {
+    renderHeader();
+    expect(screen.getByRole('link', { name: /xelma home/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/Notifications.test.tsx
+++ b/src/components/__tests__/Notifications.test.tsx
@@ -36,7 +36,9 @@ describe('Notifications', () => {
     const mockedApi = vi.mocked(api.notificationsApi);
     mockedApi.getUnreadCount.mockResolvedValue({ unread: 3 });
     render(<NotificationsBell />);
-    await waitFor(() => expect(screen.getByLabelText('Open notifications')).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /open notifications/i })).toBeTruthy(),
+    );
     expect(screen.getByText('3')).toBeTruthy();
   });
 
@@ -52,7 +54,7 @@ describe('Notifications', () => {
     await waitFor(() => expect(screen.getByText('1')).toBeTruthy());
 
     // open panel
-    fireEvent.click(screen.getByLabelText('Open notifications'));
+    fireEvent.click(screen.getByRole('button', { name: /open notifications/i }));
 
     await waitFor(() => expect(screen.getByText('Notifications')).toBeTruthy());
     expect(screen.getByText('Round Update')).toBeTruthy();
@@ -64,9 +66,11 @@ describe('Notifications', () => {
     mockedApi.getNotifications.mockResolvedValue([]);
 
     render(<NotificationsBell />);
-    await waitFor(() => expect(screen.getByLabelText('Open notifications')).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /open notifications/i })).toBeTruthy(),
+    );
 
-    fireEvent.click(screen.getByLabelText('Open notifications'));
+    fireEvent.click(screen.getByRole('button', { name: /open notifications/i }));
 
     await waitFor(() => expect(screen.getByText('No notifications')).toBeTruthy());
   });
@@ -77,7 +81,9 @@ describe('Notifications', () => {
     mockedApi.getNotifications.mockResolvedValue([]);
 
     render(<NotificationsBell />);
-    await waitFor(() => expect(screen.getByLabelText('Open notifications')).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /open notifications/i })).toBeTruthy(),
+    );
 
     // trigger incoming notification
     const payload = { id: 'r1', title: 'Live Event', message: 'An event happened', createdAt: new Date().toISOString() };
@@ -89,7 +95,7 @@ describe('Notifications', () => {
     await waitFor(() => expect(screen.getByText('1')).toBeTruthy());
 
     // open panel and it should include the live notification
-    fireEvent.click(screen.getByLabelText('Open notifications'));
+    fireEvent.click(screen.getByRole('button', { name: /open notifications/i }));
     await waitFor(() => expect(screen.getByText('Live Event')).toBeTruthy());
   });
 
@@ -103,11 +109,11 @@ describe('Notifications', () => {
 
     render(<NotificationsBell />);
     await waitFor(() => expect(screen.getByText('1')).toBeTruthy());
-    fireEvent.click(screen.getByLabelText('Open notifications'));
+    fireEvent.click(screen.getByRole('button', { name: /open notifications/i }));
 
     await waitFor(() => expect(screen.getByText('To Read')).toBeTruthy());
     // click mark-as-read button
-    const markButton = screen.getByLabelText('Mark as read');
+    const markButton = screen.getByRole('button', { name: /mark notification/i });
     fireEvent.click(markButton);
 
     // badge should disappear

--- a/src/components/education/GuideCard.tsx
+++ b/src/components/education/GuideCard.tsx
@@ -9,11 +9,12 @@ interface GuideCardProps {
 
 export const GuideCard = ({ guide, className }: GuideCardProps) => {
     return (
-        <div
+        <article
             className={cn(
                 "group relative flex flex-col overflow-hidden rounded-2xl border border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:border-[#2C4BFD]/30 dark:hover:border-[#2C4BFD]/50",
                 className
             )}
+            aria-labelledby={`guide-title-${guide.id}`}
         >
             <div className="aspect-[16/9] w-full overflow-hidden bg-gray-100 dark:bg-gray-800">
                 {guide.imageUrl ? (
@@ -24,7 +25,7 @@ export const GuideCard = ({ guide, className }: GuideCardProps) => {
                     />
                 ) : (
                     <div className="flex h-full w-full items-center justify-center bg-linear-to-br from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20">
-                        <BookOpen className="h-10 w-10 text-blue-500/50" />
+                        <BookOpen className="h-10 w-10 text-blue-500/50" aria-hidden />
                     </div>
                 )}
             </div>
@@ -34,13 +35,16 @@ export const GuideCard = ({ guide, className }: GuideCardProps) => {
                     <span className="inline-flex items-center rounded-full bg-blue-50 dark:bg-blue-900/30 px-2.5 py-0.5 text-xs font-medium text-blue-600 dark:text-blue-400">
                         {guide.category}
                     </span>
-                    <span className="inline-flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
-                        <Clock className="h-3 w-3" />
+                    <span className="inline-flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+                        <Clock className="h-3 w-3 shrink-0" aria-hidden />
                         {guide.readTime}
                     </span>
                 </div>
 
-                <h3 className="mb-2 text-xl font-bold text-gray-900 dark:text-white group-hover:text-[#2C4BFD] transition-colors">
+                <h3
+                    id={`guide-title-${guide.id}`}
+                    className="mb-2 text-xl font-bold text-gray-900 dark:text-white group-hover:text-[#2C4BFD] transition-colors"
+                >
                     {guide.title}
                 </h3>
 
@@ -48,21 +52,22 @@ export const GuideCard = ({ guide, className }: GuideCardProps) => {
                     {guide.description}
                 </p>
 
-                <div className="mt-auto flex items-center justify-between">
+                <div className="mt-auto flex items-center justify-between gap-2">
                     <a
                         href={guide.externalLink || "#"}
-                        className="inline-flex items-center gap-1 text-sm font-semibold text-[#2C4BFD] hover:underline"
+                        className="inline-flex items-center gap-1 text-sm font-semibold text-[#2C4BFD] hover:underline rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
+                        aria-label={guide.externalLink ? `Read guide: ${guide.title} (opens in a new tab)` : `Read guide: ${guide.title}`}
                         target={guide.externalLink ? "_blank" : undefined}
                         rel={guide.externalLink ? "noopener noreferrer" : undefined}
                     >
                         Read Guide
-                        <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                        <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-1" aria-hidden />
                     </a>
-                    <span className="text-[10px] uppercase tracking-wider text-gray-400 dark:text-gray-600 font-bold">
+                    <span className="text-[10px] uppercase tracking-wider text-gray-500 dark:text-gray-500 font-bold tabular-nums">
                         {new Date(guide.createdAt).toLocaleDateString(undefined, { month: 'short', year: 'numeric' })}
                     </span>
                 </div>
             </div>
-        </div>
+        </article>
     );
 };

--- a/src/components/education/TipCard.tsx
+++ b/src/components/education/TipCard.tsx
@@ -9,27 +9,32 @@ interface TipCardProps {
 
 export const TipCard = ({ tip, className }: TipCardProps) => {
     return (
-        <div
+        <article
             className={cn(
                 "relative overflow-hidden rounded-2xl bg-linear-to-br from-indigo-600 to-blue-700 p-6 text-white shadow-lg",
                 className
             )}
+            aria-labelledby={`tip-title-${tip.id}`}
         >
-            <div className="absolute -right-4 -top-4 text-white/10">
+            <div className="absolute -right-4 -top-4 text-white/10 pointer-events-none" aria-hidden>
                 <Sparkles size={120} />
             </div>
 
             <div className="relative flex flex-col gap-4">
-                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white/20 backdrop-blur-sm">
+                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white/20 backdrop-blur-sm" aria-hidden>
                     <Lightbulb className="h-6 w-6 text-yellow-300" />
                 </div>
 
                 <div>
-                    <h3 className="text-lg font-bold text-blue-100 uppercase tracking-wider mb-1">
+                    <h3
+                        id={`tip-title-${tip.id}`}
+                        className="text-lg font-bold text-white uppercase tracking-wider mb-1"
+                    >
                         {tip.title || "Daily Alpha Tip"}
                     </h3>
-                    <p className="text-xl font-medium leading-relaxed">
-                        "{tip.content}"
+                    <p className="text-xl font-medium leading-relaxed text-white">
+                        <span className="sr-only">Tip: </span>
+                        &ldquo;{tip.content}&rdquo;
                     </p>
                 </div>
 
@@ -41,6 +46,6 @@ export const TipCard = ({ tip, className }: TipCardProps) => {
                     </div>
                 )}
             </div>
-        </div>
+        </article>
     );
 };

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -47,20 +47,29 @@ type UserPredictionsResponse =
         data?: UserPrediction[];
     };
 
-function normalizeUserPredictions(response: UserPredictionsResponse): UserPrediction[] {
+function normalizeArrayResponse<T>(
+    response: T[] | Record<string, unknown>,
+    keys: string[]
+): T[] {
     if (Array.isArray(response)) {
         return response;
     }
 
-    if (Array.isArray(response.predictions)) {
-        return response.predictions;
-    }
-
-    if (Array.isArray(response.data)) {
-        return response.data;
+    for (const key of keys) {
+        const value = response[key];
+        if (Array.isArray(value)) {
+            return value as T[];
+        }
     }
 
     return [];
+}
+
+function normalizeUserPredictions(response: UserPredictionsResponse): UserPrediction[] {
+    return normalizeArrayResponse<UserPrediction>(
+        response as UserPrediction[] | Record<string, unknown>,
+        ['predictions', 'data']
+    );
 }
 
 export const predictionsApi = {
@@ -151,10 +160,10 @@ export interface LeaderboardEntry {
 type LeaderboardResponse = LeaderboardEntry[] | { data?: LeaderboardEntry[]; leaderboard?: LeaderboardEntry[] };
 
 function normalizeLeaderboard(response: LeaderboardResponse): LeaderboardEntry[] {
-    if (Array.isArray(response)) return response;
-    if (Array.isArray(response.data)) return response.data;
-    if (Array.isArray(response.leaderboard)) return response.leaderboard;
-    return [];
+    return normalizeArrayResponse<LeaderboardEntry>(
+        response as LeaderboardEntry[] | Record<string, unknown>,
+        ['data', 'leaderboard']
+    );
 }
 
 export const leaderboardApi = {

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const clearAuthMock = vi.fn();
+
+vi.mock('../store/useAuthStore', () => ({
+  useAuthStore: {
+    getState: () => ({
+      jwt: 'test-jwt',
+      clearAuth: clearAuthMock,
+    }),
+  },
+}));
+
+describe('apiFetch', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    clearAuthMock.mockReset();
+  });
+
+  it('returns JSON on 200', async () => {
+    const payload = { ok: true };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).resolves.toEqual(payload);
+  });
+
+  it('throws typed error on 400 with backend message', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message: 'Bad request payload', code: 'BAD_REQUEST' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).rejects.toMatchObject({
+      message: 'Bad request payload',
+      status: 400,
+      code: 'BAD_REQUEST',
+    });
+  });
+
+  it('clears auth and throws on 401', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).rejects.toMatchObject({ status: 401 });
+    expect(clearAuthMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses actionable fallback message on 500', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('Internal Error', { status: 500 }))
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).rejects.toMatchObject({
+      status: 500,
+      message: 'Server error. Please try again shortly.',
+    });
+  });
+
+  it('throws timeout code on aborted request', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('Aborted', 'AbortError'));
+          });
+        });
+      })
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test', { timeoutMs: 1 })).rejects.toMatchObject({
+      code: 'TIMEOUT',
+      message: 'Request timed out. Please try again.',
+    });
+  });
+});
+

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,23 +1,88 @@
 import { useAuthStore } from '../store/useAuthStore';
 
 const API_BASE = import.meta.env.VITE_API_URL ?? '';
+const DEFAULT_TIMEOUT_MS = 15000;
 
 export interface ApiErrorShape {
   message: string;
   status: number;
+  code?: string;
+  details?: unknown;
 }
 
 export class ApiError extends Error {
   status: number;
-  constructor(message: string, status: number) {
+  code?: string;
+  details?: unknown;
+  endpoint?: string;
+
+  constructor(message: string, status: number, code?: string, details?: unknown, endpoint?: string) {
     super(message);
     this.status = status;
+    this.code = code;
+    this.details = details;
+    this.endpoint = endpoint;
     this.name = 'ApiError';
   }
 }
 
-export async function apiFetch<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+export interface ApiFetchOptions extends RequestInit {
+  timeoutMs?: number;
+}
+
+interface ErrorPayload {
+  message?: unknown;
+  error?: unknown;
+  code?: unknown;
+  details?: unknown;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+async function parseErrorPayload(response: Response): Promise<ErrorPayload | null> {
+  try {
+    const clone = response.clone();
+    const json = await clone.json();
+    return (json && typeof json === 'object') ? (json as ErrorPayload) : null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultMessageForStatus(status: number, endpoint: string): string {
+  if (status === 400) return 'Invalid request. Please check your input and try again.';
+  if (status === 401) return 'Your session has expired. Please reconnect and try again.';
+  if (status === 403) return 'You do not have permission to perform this action.';
+  if (status === 404) return 'Requested resource was not found.';
+  if (status >= 500) return 'Server error. Please try again shortly.';
+  return `Request failed: ${endpoint}`;
+}
+
+function createApiError(endpoint: string, status: number, payload: ErrorPayload | null): ApiError {
+  const message =
+    asString(payload?.message) ??
+    asString(payload?.error) ??
+    defaultMessageForStatus(status, endpoint);
+  const code = asString(payload?.code) ?? undefined;
+  const details = payload?.details;
+  return new ApiError(message, status, code, details, endpoint);
+}
+
+export function normalizeApiError(error: unknown, fallbackMessage = 'Something went wrong. Please try again.'): ApiError {
+  if (error instanceof ApiError) {
+    return error;
+  }
+  if (error instanceof Error) {
+    return new ApiError(error.message || fallbackMessage, 0, 'UNKNOWN', undefined);
+  }
+  return new ApiError(fallbackMessage, 0, 'UNKNOWN', undefined);
+}
+
+export async function apiFetch<T>(endpoint: string, options: ApiFetchOptions = {}): Promise<T> {
   const { jwt, clearAuth } = useAuthStore.getState();
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -28,20 +93,47 @@ export async function apiFetch<T>(endpoint: string, options: RequestInit = {}): 
     headers['Authorization'] = `Bearer ${jwt}`;
   }
 
-  const response = await fetch(`${API_BASE}${endpoint}`, {
-    ...options,
-    headers,
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const requestOptions: RequestInit = { ...options };
+  delete (requestOptions as Record<string, unknown>).timeoutMs;
 
-  if (response.status === 401) {
-    clearAuth();
-    throw new ApiError('Unauthorized: session expired', 401);
+  try {
+    const response = await fetch(`${API_BASE}${endpoint}`, {
+      ...requestOptions,
+      headers,
+      signal: requestOptions.signal ?? controller.signal,
+    });
+
+    if (response.status === 401) {
+      clearAuth();
+    }
+
+    if (!response.ok) {
+      const payload = await parseErrorPayload(response);
+      const apiError = createApiError(endpoint, response.status, payload);
+      if (import.meta.env.DEV) {
+        console.debug('[apiFetch:error]', {
+          endpoint,
+          status: apiError.status,
+          code: apiError.code,
+          message: apiError.message,
+        });
+      }
+      throw apiError;
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return response.json() as Promise<T>;
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new ApiError('Request timed out. Please try again.', 0, 'TIMEOUT', undefined, endpoint);
+    }
+    throw normalizeApiError(error, 'Network error. Please check your connection and try again.');
+  } finally {
+    clearTimeout(timeout);
   }
-
-  if (!response.ok) {
-    const text = await response.text().catch(() => response.statusText);
-    throw new ApiError(text || `Request failed: ${endpoint}`, response.status);
-  }
-
-  return response.json() as Promise<T>;
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,7 +5,7 @@ import PredictionCard from "../components/PredictionCard";
 import type { PredictionData } from "../components/PredictionControls";
 import { useRoundStore } from "../store/useRoundStore";
 import PredictionHistory from "../components/PredictionHistory";
-import { useWalletStore } from "../store/useWalletStore";
+import { useWalletStore, selectIsWalletConnected } from "../store/useWalletStore";
 import { predictionsApi, ApiError } from "../lib/api-client";
 
 interface DashboardProps {
@@ -14,7 +14,11 @@ interface DashboardProps {
 
 const Dashboard = ({ showNewsRibbon = true }: DashboardProps) => {
   const isRoundActive = useRoundStore((state) => state.isRoundActive);
-  const publicKey = useWalletStore((state) => state.publicKey);
+  const isWalletConnected = useWalletStore(selectIsWalletConnected);
+  const isWalletConnecting = useWalletStore(
+    (s) => s.status === "connecting" || s.status === "checking"
+  );
+  const publicKey = useWalletStore((s) => s.publicKey);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const timeoutRef = useRef<number | null>(null);
@@ -98,9 +102,10 @@ const Dashboard = ({ showNewsRibbon = true }: DashboardProps) => {
           {/* Center: Prediction controls (Issue: core prediction area) */}
           <div className="dashboard__center lg:col-span-1 flex flex-col gap-6">
             <PredictionCard
-              isWalletConnected={true}
+              isWalletConnected={isWalletConnected}
               isRoundActive={isRoundActive}
-              isConnecting={isSubmitting}
+              isConnecting={isWalletConnecting}
+              isSubmittingPrediction={isSubmitting}
               onPrediction={handlePrediction}
             />
           </div>

--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from "react";
 import { educationApi } from "../lib/api-client";
+import { normalizeApiError } from "../lib/api";
 import type { Guide, Tip } from "../types/education";
 import { GuideCard } from "../components/education/GuideCard";
 import { TipCard } from "../components/education/TipCard";
@@ -25,7 +26,8 @@ const LearnPage = () => {
             if (guidesResult.status === 'fulfilled') {
                 setGuides(guidesResult.value);
             } else {
-                console.error("Failed to fetch guides:", guidesResult.reason);
+                const err = normalizeApiError(guidesResult.reason, "Failed to fetch guides");
+                console.debug("Failed to fetch guides", { message: err.message, status: err.status, code: err.code });
                 // We only set a general error if both or critical one fails, 
                 // but requirement says "one failure does not block the other"
             }
@@ -33,7 +35,8 @@ const LearnPage = () => {
             if (tipResult.status === 'fulfilled') {
                 setTip(tipResult.value);
             } else {
-                console.error("Failed to fetch tip:", tipResult.reason);
+                const err = normalizeApiError(tipResult.reason, "Failed to fetch tip");
+                console.debug("Failed to fetch tip", { message: err.message, status: err.status, code: err.code });
             }
 
             // If both failed, show error
@@ -41,7 +44,8 @@ const LearnPage = () => {
                 setError("Unable to load education content. Please check your connection.");
             }
         } catch (err) {
-            setError(err instanceof Error ? err.message : "An unexpected error occurred");
+            const normalized = normalizeApiError(err, "An unexpected error occurred");
+            setError(normalized.message);
         } finally {
             setLoading(false);
         }

--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -75,12 +75,12 @@ const LearnPage = () => {
         <div className="container mx-auto px-4 py-8 lg:py-12 max-w-7xl animate-in fade-in duration-700">
             <header className="mb-12 text-center">
                 <div className="inline-flex items-center justify-center p-3 mb-4 rounded-2xl bg-blue-50 dark:bg-blue-900/20 text-[#2C4BFD]">
-                    <GraduationCap size={32} />
+                    <GraduationCap size={32} aria-hidden />
                 </div>
                 <h1 className="text-4xl lg:text-5xl font-black text-gray-900 dark:text-white mb-4 tracking-tight">
                     Xelma Academy
                 </h1>
-                <p className="text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
+                <p className="text-lg text-gray-700 dark:text-gray-300 max-w-2xl mx-auto">
                     Master the art of prediction. Learn strategies, understand the Stellar ecosystem, and level up your trading game.
                 </p>
             </header>
@@ -88,10 +88,12 @@ const LearnPage = () => {
             <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
                 {/* Main Content: Guides */}
                 <div className="lg:col-span-8 space-y-8">
-                    <section>
+                    <section aria-labelledby="learn-guides-heading">
                         <div className="flex items-center gap-3 mb-8">
-                            <BookMarked className="text-[#2C4BFD]" size={24} />
-                            <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Expert Guides</h2>
+                            <BookMarked className="text-[#2C4BFD] shrink-0" size={24} aria-hidden />
+                            <h2 id="learn-guides-heading" className="text-2xl font-bold text-gray-900 dark:text-white">
+                                Expert Guides
+                            </h2>
                         </div>
 
                         {guides.length > 0 ? (
@@ -112,11 +114,13 @@ const LearnPage = () => {
                 </div>
 
                 {/* Sidebar: Tip of the day */}
-                <aside className="lg:col-span-4">
+                <aside className="lg:col-span-4" aria-label="Tips and community">
                     <div className="sticky top-32 space-y-6">
-                        <section>
+                        <section aria-labelledby="learn-tip-heading">
                             <div className="flex items-center gap-3 mb-6">
-                                <h2 className="text-xl font-bold text-gray-900 dark:text-white">Quick Alpha</h2>
+                                <h2 id="learn-tip-heading" className="text-xl font-bold text-gray-900 dark:text-white">
+                                    Quick Alpha
+                                </h2>
                             </div>
 
                             {tip ? (
@@ -133,11 +137,14 @@ const LearnPage = () => {
 
                         {/* Additional info box */}
                         <div className="p-6 rounded-2xl border border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900">
-                            <h3 className="font-bold mb-2">Want to contribute?</h3>
-                            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+                            <h3 className="font-bold mb-2 text-gray-900 dark:text-white">Want to contribute?</h3>
+                            <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
                                 Are you an expert in Stellar or prediction markets? Share your knowledge with the community.
                             </p>
-                            <button className="w-full py-2 px-4 rounded-xl text-sm font-bold border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+                            <button
+                                type="button"
+                                className="w-full py-2 px-4 rounded-xl text-sm font-bold border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
+                            >
                                 Apply as Educator
                             </button>
                         </div>

--- a/src/store/useNotificationsStore.ts
+++ b/src/store/useNotificationsStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import type { NotificationItem, NotificationEventPayload } from '../types/notification';
 import { notificationsApi } from '../lib/api-client';
+import { normalizeApiError } from '../lib/api';
 
 interface NotificationsState {
   unread: number;
@@ -29,8 +30,8 @@ export const useNotificationsStore = create<NotificationsState>()((set, get) => 
       const res = await notificationsApi.getUnreadCount();
       set({ unread: res.unread });
     } catch (rawErr) {
-      const msg = rawErr instanceof Error ? rawErr.message : 'Failed to load unread count';
-      set({ errorCount: msg });
+      const err = normalizeApiError(rawErr, 'Failed to load unread count');
+      set({ errorCount: err.message });
     } finally {
       set({ loadingCount: false });
     }
@@ -49,8 +50,8 @@ export const useNotificationsStore = create<NotificationsState>()((set, get) => 
         return { list: merged };
       });
     } catch (rawErr) {
-      const msg = rawErr instanceof Error ? rawErr.message : 'Failed to load notifications';
-      set({ errorList: msg });
+      const err = normalizeApiError(rawErr, 'Failed to load notifications');
+      set({ errorList: err.message });
     } finally {
       set({ loadingList: false });
     }

--- a/src/store/useProfileStore.ts
+++ b/src/store/useProfileStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { useAuthStore } from './useAuthStore';
+import { normalizeApiError } from '../lib/api';
 import {
   fetchProfile,
   updateProfile,
@@ -57,11 +58,12 @@ export const useProfileStore = create<ProfileState>((set) => ({
       writeLocalCache(data);
       set({ profile: data, isLoading: false, error: null });
     } catch (err) {
+      const normalized = normalizeApiError(err, 'Failed to load profile');
       const cached = readLocalCache();
       set({
         profile: cached,
         isLoading: false,
-        error: err instanceof Error ? err.message : 'Failed to load profile',
+        error: normalized.message,
       });
     }
   },
@@ -81,10 +83,11 @@ export const useProfileStore = create<ProfileState>((set) => ({
       set({ profile: saved, error: null });
       return true;
     } catch (err) {
+      const normalized = normalizeApiError(err, 'Failed to save profile');
       writeLocalCache(data);
       set({
         profile: data,
-        error: err instanceof Error ? err.message : 'Failed to save profile',
+        error: normalized.message,
       });
       return false;
     }

--- a/src/store/useRoundStore.test.ts
+++ b/src/store/useRoundStore.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../lib/api-client', () => ({
+  roundsApi: {
+    getActive: vi.fn(),
+  },
+}));
+
+import { roundsApi } from '../lib/api-client';
+import { useRoundStore } from './useRoundStore';
+import { ApiError } from '../lib/api';
+
+describe('useRoundStore error handling', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    useRoundStore.setState({
+      activeRound: null,
+      isRoundActive: false,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('sets actionable message when round fetch fails with ApiError', async () => {
+    vi.mocked(roundsApi.getActive).mockRejectedValueOnce(
+      new ApiError('Server error. Please try again shortly.', 500, 'INTERNAL')
+    );
+
+    await useRoundStore.getState().fetchActiveRound();
+
+    const state = useRoundStore.getState();
+    expect(state.activeRound).toBeNull();
+    expect(state.isRoundActive).toBe(false);
+    expect(state.error).toBe('Server error. Please try again shortly.');
+  });
+});
+

--- a/src/store/useRoundStore.ts
+++ b/src/store/useRoundStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { roundsApi, type Round } from '../lib/api-client';
+import { normalizeApiError } from '../lib/api';
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 
@@ -78,11 +79,12 @@ export const useRoundStore = create<RoundStore>((set) => ({
       const activeRound = await roundsApi.getActive();
       set({ activeRound, isRoundActive: !!activeRound, isLoading: false });
     } catch (error) {
+      const normalized = normalizeApiError(error, 'Failed to fetch active round');
       set({
         activeRound: null,
         isRoundActive: false,
         isLoading: false,
-        error: error instanceof Error ? error.message : 'Failed to fetch active round',
+        error: normalized.message,
       });
     }
   },

--- a/src/store/useWalletStore.test.ts
+++ b/src/store/useWalletStore.test.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const clearAuth = vi.fn();
+const setJwt = vi.fn();
+
+vi.mock('./useAuthStore', () => ({
+  useAuthStore: {
+    getState: () => ({
+      clearAuth,
+      setJwt,
+      isAuthenticated: false,
+    }),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@stellar/freighter-api', () => ({
+  isConnected: vi.fn(),
+  requestAccess: vi.fn(),
+  getAddress: vi.fn(),
+  getNetwork: vi.fn(),
+  signMessage: vi.fn(),
+}));
+
+import {
+  isConnected,
+  requestAccess,
+  getAddress,
+  getNetwork,
+  signMessage,
+} from '@stellar/freighter-api';
+import { useWalletStore, selectIsWalletConnected } from './useWalletStore';
+
+function resetWalletState() {
+  useWalletStore.setState({
+    status: 'idle',
+    publicKey: null,
+    network: null,
+    balance: null,
+    errorMessage: null,
+    errorCode: null,
+    networkMismatch: false,
+  });
+}
+
+describe('selectIsWalletConnected', () => {
+  beforeEach(() => {
+    resetWalletState();
+  });
+
+  it('is true only when status is connected and publicKey is set', () => {
+    useWalletStore.setState({ status: 'connected', publicKey: 'GABC' });
+    expect(selectIsWalletConnected(useWalletStore.getState())).toBe(true);
+
+    useWalletStore.setState({ status: 'connecting', publicKey: 'GABC' });
+    expect(selectIsWalletConnected(useWalletStore.getState())).toBe(false);
+
+    useWalletStore.setState({ status: 'connected', publicKey: null });
+    expect(selectIsWalletConnected(useWalletStore.getState())).toBe(false);
+  });
+});
+
+describe('useWalletStore', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    clearAuth.mockClear();
+    setJwt.mockClear();
+    resetWalletState();
+  });
+
+  it('disconnect clears wallet and calls clearAuth', () => {
+    useWalletStore.setState({
+      status: 'connected',
+      publicKey: 'GKEY',
+      network: 'TESTNET',
+      balance: '1.00 XLM',
+    });
+
+    useWalletStore.getState().disconnect();
+
+    const s = useWalletStore.getState();
+    expect(s.status).toBe('idle');
+    expect(s.publicKey).toBeNull();
+    expect(clearAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('clearError removes error fields', () => {
+    useWalletStore.setState({
+      status: 'error',
+      errorMessage: 'oops',
+      errorCode: 'UNKNOWN',
+    });
+    useWalletStore.getState().clearError();
+    expect(useWalletStore.getState().errorMessage).toBeNull();
+    expect(useWalletStore.getState().errorCode).toBeNull();
+  });
+
+  it('checkConnection sets idle when Freighter is not connected', async () => {
+    vi.mocked(isConnected).mockResolvedValue({ isConnected: false });
+
+    await useWalletStore.getState().checkConnection();
+
+    const s = useWalletStore.getState();
+    expect(s.status).toBe('idle');
+    expect(s.publicKey).toBeNull();
+    expect(isConnected).toHaveBeenCalled();
+  });
+
+  it('checkConnection restores connected state with address and TESTNET', async () => {
+    vi.mocked(isConnected).mockResolvedValue({ isConnected: true });
+    vi.mocked(getAddress).mockResolvedValue({ address: 'GADDR', error: undefined });
+    vi.mocked(getNetwork).mockResolvedValue({
+      network: 'TESTNET',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      error: undefined,
+    } as Awaited<ReturnType<typeof getNetwork>>);
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        balances: [{ asset_type: 'native', balance: '10.5' }],
+      }),
+    }) as unknown as typeof fetch;
+
+    await useWalletStore.getState().checkConnection();
+
+    const s = useWalletStore.getState();
+    expect(s.status).toBe('connected');
+    expect(s.publicKey).toBe('GADDR');
+    expect(s.networkMismatch).toBe(false);
+    expect(s.balance).toBe('10.50 XLM');
+  });
+
+  it('dedupes concurrent checkConnection into one Freighter round-trip', async () => {
+    let resolveConnected!: (v: { isConnected: boolean }) => void;
+    const connectedPromise = new Promise<{ isConnected: boolean }>((res) => {
+      resolveConnected = res;
+    });
+
+    vi.mocked(isConnected).mockReturnValue(connectedPromise as never);
+    vi.mocked(getAddress).mockResolvedValue({ address: 'G1', error: undefined });
+    vi.mocked(getNetwork).mockResolvedValue({
+      network: 'TESTNET',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      error: undefined,
+    } as Awaited<ReturnType<typeof getNetwork>>);
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        balances: [{ asset_type: 'native', balance: '1' }],
+      }),
+    }) as unknown as typeof fetch;
+
+    const p1 = useWalletStore.getState().checkConnection();
+    const p2 = useWalletStore.getState().checkConnection();
+    resolveConnected({ isConnected: true });
+    await Promise.all([p1, p2]);
+
+    expect(isConnected).toHaveBeenCalledTimes(1);
+    expect(useWalletStore.getState().publicKey).toBe('G1');
+  });
+
+  it('connect sets error when Freighter never becomes available', async () => {
+    vi.mocked(isConnected).mockResolvedValue({ isConnected: false });
+
+    await useWalletStore.getState().connect();
+
+    const s = useWalletStore.getState();
+    expect(s.status).toBe('error');
+    expect(s.errorCode).toBe('FREIGHTER_UNAVAILABLE');
+    expect(s.publicKey).toBeNull();
+  });
+
+  it('connect reaches connected and authenticates when APIs succeed', async () => {
+    vi.mocked(isConnected).mockResolvedValue({ isConnected: true });
+    vi.mocked(requestAccess).mockResolvedValue({
+      address: 'GSIGNER',
+      error: undefined,
+    });
+    vi.mocked(getNetwork).mockResolvedValue({
+      network: 'TESTNET',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      error: undefined,
+    } as Awaited<ReturnType<typeof getNetwork>>);
+    vi.mocked(signMessage).mockResolvedValue({
+      signedMessage: 'sig',
+      signerAddress: 'GSIGNER',
+      error: undefined,
+    } as Awaited<ReturnType<typeof signMessage>>);
+
+    const fetchMock = vi.fn((url: string) => {
+      if (url.includes('horizon-testnet')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            balances: [{ asset_type: 'native', balance: '2' }],
+          }),
+        });
+      }
+      if (url.includes('/api/auth/challenge')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ challenge: 'challenge-bytes' }),
+        });
+      }
+      if (url.includes('/api/auth/connect')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ token: 'jwt-1' }),
+        });
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`));
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await useWalletStore.getState().connect();
+
+    const s = useWalletStore.getState();
+    expect(s.status).toBe('connected');
+    expect(s.publicKey).toBe('GSIGNER');
+    expect(setJwt).toHaveBeenCalledWith('jwt-1');
+    expect(s.errorCode).not.toBe('AUTH_FAILED');
+  });
+
+  it('connect keeps wallet connected but sets AUTH_FAILED when backend rejects', async () => {
+    vi.mocked(isConnected).mockResolvedValue({ isConnected: true });
+    vi.mocked(requestAccess).mockResolvedValue({
+      address: 'GSIGNER',
+      error: undefined,
+    });
+    vi.mocked(getNetwork).mockResolvedValue({
+      network: 'TESTNET',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      error: undefined,
+    } as Awaited<ReturnType<typeof getNetwork>>);
+    vi.mocked(signMessage).mockResolvedValue({
+      signedMessage: 'sig',
+      signerAddress: 'GSIGNER',
+      error: undefined,
+    } as Awaited<ReturnType<typeof signMessage>>);
+
+    const fetchMock = vi.fn((url: string) => {
+      if (url.includes('horizon-testnet')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            balances: [{ asset_type: 'native', balance: '2' }],
+          }),
+        });
+      }
+      if (url.includes('/api/auth/challenge')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ challenge: 'challenge-bytes' }),
+        });
+      }
+      if (url.includes('/api/auth/connect')) {
+        return Promise.resolve({ ok: false, status: 401 });
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`));
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await useWalletStore.getState().connect();
+
+    const s = useWalletStore.getState();
+    expect(s.status).toBe('connected');
+    expect(s.publicKey).toBe('GSIGNER');
+    expect(clearAuth).toHaveBeenCalled();
+    expect(s.errorCode).toBe('AUTH_FAILED');
+    expect(s.errorMessage).toMatch(/sign-in/i);
+  });
+});

--- a/src/store/useWalletStore.ts
+++ b/src/store/useWalletStore.ts
@@ -11,26 +11,177 @@ import { useAuthStore } from './useAuthStore';
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 
+/** Single source of truth for wallet UI + lifecycle (issue #71). */
+export type WalletStatus = 'idle' | 'checking' | 'connecting' | 'connected' | 'error';
+
+export type WalletErrorCode =
+  | 'FREIGHTER_UNAVAILABLE'
+  | 'ACCESS_DENIED'
+  | 'TIMEOUT'
+  | 'BALANCE_FAILED'
+  | 'NETWORK_MISMATCH'
+  | 'AUTH_FAILED'
+  | 'UNKNOWN';
+
 interface WalletState {
+  status: WalletStatus;
   publicKey: string | null;
   network: string | null;
   balance: string | null;
-  isConnecting: boolean;
+  /** Last user-visible error (cleared on successful connect/check). */
+  errorMessage: string | null;
+  errorCode: WalletErrorCode | null;
+  /** True when Freighter reports a network other than TESTNET (still connected). */
+  networkMismatch: boolean;
   connect: () => Promise<void>;
   disconnect: () => void;
   checkConnection: () => Promise<void>;
+  clearError: () => void;
 }
 
-export const useWalletStore = create<WalletState>((set) => ({
+/** Dedupe concurrent checkConnection calls (remount / multiple headers). */
+let checkConnectionInFlight: Promise<void> | null = null;
+
+function mapConnectError(err: unknown): { message: string; code: WalletErrorCode } {
+  const msg = err instanceof Error ? err.message : String(err);
+  const lower = msg.toLowerCase();
+  if (lower.includes('denied') || lower.includes('rejected') || lower.includes('user denied')) {
+    return { message: 'Wallet access was denied. Click Connect and approve in Freighter.', code: 'ACCESS_DENIED' };
+  }
+  if (lower.includes('timeout') || lower.includes('timed out')) {
+    return { message: 'Connection timed out. Check Freighter and try again.', code: 'TIMEOUT' };
+  }
+  return { message: 'Could not connect wallet. Try again or reinstall Freighter.', code: 'UNKNOWN' };
+}
+
+export const selectIsWalletConnected = (s: WalletState): boolean =>
+  s.status === 'connected' && Boolean(s.publicKey);
+
+export const useWalletStore = create<WalletState>((set, get) => ({
+  status: 'idle',
   publicKey: null,
   network: null,
   balance: null,
-  isConnecting: false,
+  errorMessage: null,
+  errorCode: null,
+  networkMismatch: false,
+
+  clearError: () => set({ errorMessage: null, errorCode: null }),
+
+  disconnect: () => {
+    set({
+      status: 'idle',
+      publicKey: null,
+      network: null,
+      balance: null,
+      errorMessage: null,
+      errorCode: null,
+      networkMismatch: false,
+    });
+    useAuthStore.getState().clearAuth();
+    toast.success('Wallet disconnected');
+  },
+
+  checkConnection: async () => {
+    if (checkConnectionInFlight) {
+      return checkConnectionInFlight;
+    }
+
+    checkConnectionInFlight = (async () => {
+      const prev = get();
+      if (prev.status === 'connecting') return;
+
+      set({ status: 'checking', errorMessage: null, errorCode: null });
+
+      try {
+        const { isConnected: freighterConnected } = await isConnected();
+        if (!freighterConnected) {
+          set({
+            status: 'idle',
+            publicKey: null,
+            network: null,
+            balance: null,
+            networkMismatch: false,
+          });
+          return;
+        }
+
+        const { address } = await getAddress();
+        if (!address) {
+          set({
+            status: 'idle',
+            publicKey: null,
+            network: null,
+            balance: null,
+            networkMismatch: false,
+          });
+          return;
+        }
+
+        const { network } = await getNetwork();
+        const net = (network as string | null) || null;
+        const networkMismatch = net !== 'TESTNET';
+
+        let formattedBalance: string | null = null;
+        try {
+          const response = await fetch(`https://horizon-testnet.stellar.org/accounts/${address}`);
+          if (response.status === 404) {
+            formattedBalance = '0.00 XLM';
+          } else if (!response.ok) {
+            throw new Error('Fetch failed');
+          } else {
+            const data = await response.json();
+            const balances = data.balances as Array<{ asset_type: string; balance: string }>;
+            const nativeBalance = balances.find((b) => b.asset_type === 'native');
+            formattedBalance = nativeBalance
+              ? `${parseFloat(nativeBalance.balance).toFixed(2)} XLM`
+              : '0.00 XLM';
+          }
+        } catch {
+          formattedBalance = null;
+          toast.error('Could not load balance. You can still use the app; try reconnecting if needed.');
+        }
+
+        set({
+          status: 'connected',
+          publicKey: address,
+          network: net,
+          balance: formattedBalance,
+          networkMismatch,
+          errorMessage: null,
+          errorCode: null,
+        });
+
+        if (networkMismatch) {
+          toast.error('Please switch to Stellar Testnet in Freighter for full compatibility.');
+        }
+      } catch {
+        set({
+          status: 'idle',
+          publicKey: null,
+          network: null,
+          balance: null,
+          networkMismatch: false,
+        });
+      } finally {
+        checkConnectionInFlight = null;
+      }
+    })();
+
+    return checkConnectionInFlight;
+  },
 
   connect: async () => {
-    try {
-      set({ isConnecting: true });
+    if (get().status === 'connecting') return;
 
+    set({
+      status: 'connecting',
+      errorMessage: null,
+      errorCode: null,
+      networkMismatch: false,
+    });
+
+    try {
       let connected = false;
       for (let i = 0; i < 5; i++) {
         const { isConnected: isFreighterConnected } = await isConnected();
@@ -38,39 +189,38 @@ export const useWalletStore = create<WalletState>((set) => ({
           connected = true;
           break;
         }
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await new Promise((resolve) => setTimeout(resolve, 100));
       }
 
       if (!connected) {
-        toast.error('Freighter wallet not installed!');
-        set({ isConnecting: false });
+        set({
+          status: 'error',
+          errorMessage: 'Freighter is not installed or not unlocked. Install Freighter and try again.',
+          errorCode: 'FREIGHTER_UNAVAILABLE',
+        });
+        toast.error('Freighter wallet not available');
         return;
       }
 
-      const timeoutPromise = new Promise<{ address: string; error?: string }>((_, reject) => {
-        setTimeout(() => reject(new Error("Connection timed out")), 30000); // 30 seconds timeout
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('TIMEOUT')), 30000);
       });
 
-      const { address, error } = await Promise.race([
-        requestAccess(),
-        timeoutPromise
-      ]);
+      const accessResult = await Promise.race([requestAccess(), timeoutPromise]);
+      const { address, error } = accessResult;
 
       if (error) {
-        throw new Error(error.toString());
+        throw new Error(String(error));
       }
-
       if (!address) {
         throw new Error('User denied access');
       }
 
       const { network } = await getNetwork();
+      const net = (network as string | null) || null;
+      const networkMismatch = net !== 'TESTNET';
 
-      if (network !== 'TESTNET') {
-        toast.error('Please switch to Stellar Testnet in Freighter');
-      }
-
-      let formattedBalance = '0.00 XLM';
+      let formattedBalance: string | null = null;
       try {
         const response = await fetch(`https://horizon-testnet.stellar.org/accounts/${address}`);
         if (response.status === 404) {
@@ -79,31 +229,33 @@ export const useWalletStore = create<WalletState>((set) => ({
           throw new Error('Failed to fetch account data');
         } else {
           const data = await response.json();
-          const balances = data.balances;
-          const nativeBalance = balances.find((b: { asset_type: string; balance: string }) => b.asset_type === 'native');
-
-          if (nativeBalance) {
-            formattedBalance = `${parseFloat(nativeBalance.balance).toFixed(2)} XLM`;
-          }
+          const balances = data.balances as Array<{ asset_type: string; balance: string }>;
+          const nativeBalance = balances.find((b) => b.asset_type === 'native');
+          formattedBalance = nativeBalance
+            ? `${parseFloat(nativeBalance.balance).toFixed(2)} XLM`
+            : '0.00 XLM';
         }
-      } catch (err) {
-        console.error('Failed to fetch balance:', err);
-        toast.error("Failed to fetch wallet balance");
-
-        set({ isConnecting: false });
-        return;
+      } catch {
+        formattedBalance = null;
+        toast.error('Connected, but balance could not be loaded. Try again later.');
       }
 
       set({
         publicKey: address,
-        network: (network as string | null) || null,
+        network: net,
         balance: formattedBalance,
-        isConnecting: false,
+        status: 'connected',
+        networkMismatch,
+        errorMessage: null,
+        errorCode: null,
       });
 
       toast.success('Wallet connected!');
 
-      // Backend auth: challenge → sign → JWT
+      if (networkMismatch) {
+        toast.error('Please switch to Stellar Testnet in Freighter');
+      }
+
       try {
         const challengeRes = await fetch(`${API_BASE}/api/auth/challenge`, {
           method: 'POST',
@@ -117,9 +269,10 @@ export const useWalletStore = create<WalletState>((set) => ({
 
         const { signedMessage, error: signError } = await signMessage(challenge, {
           address,
-          networkPassphrase: network === 'TESTNET'
-            ? 'Test SDF Network ; September 2015'
-            : 'Public Global Stellar Network ; September 2015',
+          networkPassphrase:
+            network === 'TESTNET'
+              ? 'Test SDF Network ; September 2015'
+              : 'Public Global Stellar Network ; September 2015',
         });
 
         if (signError) throw new Error(signError.message ?? 'Failed to sign challenge');
@@ -142,62 +295,34 @@ export const useWalletStore = create<WalletState>((set) => ({
         toast.success('Authenticated with backend!');
       } catch (authError) {
         console.error('Backend auth error:', authError);
+        useAuthStore.getState().clearAuth();
+        set({
+          errorMessage:
+            'Wallet is connected, but sign-in to the server failed. Try Disconnect and Connect again.',
+          errorCode: 'AUTH_FAILED',
+        });
         toast.error('Wallet connected but backend auth failed');
       }
     } catch (error) {
       console.error('Connection error:', error);
-      toast.error('Failed to connect wallet');
-      set({ isConnecting: false });
+      const mapped = mapConnectError(error);
+      const code: WalletErrorCode =
+        error instanceof Error && error.message === 'TIMEOUT' ? 'TIMEOUT' : mapped.code;
+      const message =
+        error instanceof Error && error.message === 'TIMEOUT'
+          ? 'Connection timed out. Unlock Freighter and try again.'
+          : mapped.message;
+
+      set({
+        status: 'error',
+        publicKey: null,
+        network: null,
+        balance: null,
+        networkMismatch: false,
+        errorMessage: message,
+        errorCode: code,
+      });
+      toast.error(message);
     }
   },
-
-  disconnect: () => {
-    set({ publicKey: null, network: null, balance: null });
-    useAuthStore.getState().clearAuth();
-    toast.success('Wallet disconnected');
-  },
-
-  checkConnection: async () => {
-    try {
-      const { isConnected: connected } = await isConnected();
-      if (connected) {
-        // use getAddress to check if we still have access without prompting
-        const { address } = await getAddress();
-
-        if (address) {
-          const { network } = await getNetwork();
-
-          let formattedBalance = '0.00 XLM';
-          try {
-            const response = await fetch(`https://horizon-testnet.stellar.org/accounts/${address}`);
-            if (response.status === 404) {
-              formattedBalance = '0.00 XLM';
-            } else if (!response.ok) {
-              throw new Error("Fetch failed");
-            } else {
-              const data = await response.json();
-              const balances = data.balances;
-              const nativeBalance = balances.find((b: { asset_type: string; balance: string }) => b.asset_type === 'native');
-
-              if (nativeBalance) {
-                formattedBalance = `${parseFloat(nativeBalance.balance).toFixed(2)} XLM`;
-              }
-            }
-          } catch (err) {
-            console.error('Failed to check balance:', err);
-            toast.error("Failed to fetch wallet balance");
-            return;
-          }
-
-          set({
-            publicKey: address,
-            network: (network as string | null) || null,
-            balance: formattedBalance
-          });
-        }
-      }
-    } catch {
-      // ignore: silently skip if Freighter is not connected on mount
-    }
-  }
 }));


### PR DESCRIPTION
## Summary
Accessibility baseline for issue #73: semantics, names, focus, landmarks, and contrast tweaks across the scoped surfaces.

## Changes
- **Skip link** → `#main-content`; **`<main id="main-content">`** in App
- **Header**: `nav` `aria-label="Primary"`, logo as home `Link`, mobile **menu button** (`aria-expanded` / `aria-controls`), theme toggle labels, focus-visible rings, list structure for nav items
- **Notifications**: non-modal `dialog` with labelled title, **Escape** closes panel, bell `aria-expanded` / `aria-controls`, unread count in accessible name, improved text contrast, per-item “mark as read” labels
- **Wallet**: always-visible **disconnect** control (no hover-only), balance screen-reader text, consistent focus rings
- **Profile settings**: `role="dialog"` `aria-modal`, real `<button>` close/save, `<label htmlFor>` for fields, avatar upload id linkage, streamer `aria-label`, loading shell `aria-busy` + sr-only text
- **End round modal**: `onOpenChange` only calls close when transitioning to closed; decorative emoji `aria-hidden`; `focus-visible` on primary action; slightly stronger description contrast
- **Learn / Guide / Tip**: `section`/`aside` wiring, `article` cards, guide CTA `aria-label`, tip typography/contrast, contribute CTA `type="button"` + focus ring

## Tests
- `Header.a11y.test.tsx`: primary nav landmark, skip link target, home link name
- Notifications tests updated for new accessible names

## Manual checklist (PR verification)
- [ ] Tab through **Header** (desktop + mobile menu): focus always visible
- [ ] **Skip to main** moves focus into main content (browser dependent; target exists)
- [ ] **Notifications**: open → Esc closes; SR/name for bell with unread count
- [ ] **Wallet** connected: Tab reaches **Disconnect**
- [ ] **Learn**: headings order (h1 → h2), guide links descriptive

## Known follow-ups (non-blocking)
- Notifications panel: no full focus trap (popover pattern); consider Radix Popover later
- Profile modal: no roving tab trap (Escape + first-field focus only)
- Automated axe/Playwright a11y suite not added in this pass

`npm run test` passes.

Closes #73
