### PR TITLE
Strengthen accessibility for dialogs and interactive controls

### DIFF
--- a/src/components/EndRoundModal.test.tsx
+++ b/src/components/EndRoundModal.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useState } from 'react';
+import EndRoundModal from './EndRoundModal';
+
+const result = {
+  isWin: true,
+  amount: 42,
+  tip: 'Stay patient and size the next prediction carefully.',
+};
+
+describe('EndRoundModal accessibility', () => {
+  it('renders an accessible modal dialog with title and description', () => {
+    render(<EndRoundModal isOpen onClose={vi.fn()} result={result} />);
+
+    const dialog = screen.getByRole('dialog', { name: /spectacular win/i });
+    expect(dialog).toHaveAttribute('aria-describedby');
+    expect(screen.getByText('You made all the right moves.')).toBeInTheDocument();
+  });
+
+  it('closes on Escape and restores focus to the trigger', async () => {
+    const onClose = vi.fn();
+
+    function EndRoundHarness() {
+      const [open, setOpen] = useState(false);
+
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open result
+          </button>
+          <EndRoundModal
+            isOpen={open}
+            onClose={() => {
+              onClose();
+              setOpen(false);
+            }}
+            result={result}
+          />
+        </>
+      );
+    }
+
+    render(<EndRoundHarness />);
+
+    const trigger = screen.getByRole('button', { name: /open result/i });
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /continue to next round/i })).toHaveFocus();
+    });
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+});

--- a/src/components/EndRoundModal.tsx
+++ b/src/components/EndRoundModal.tsx
@@ -1,4 +1,5 @@
 import * as Dialog from '@radix-ui/react-dialog';
+import { useEffect, useRef } from 'react';
 
 interface EndRoundModalProps {
   isOpen: boolean;
@@ -12,6 +13,21 @@ interface EndRoundModalProps {
 
 export default function EndRoundModal({ isOpen, onClose, result }: EndRoundModalProps) {
   const { isWin, amount, tip } = result;
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      previouslyFocusedRef.current = document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+      return;
+    }
+
+    const previouslyFocused = previouslyFocusedRef.current;
+    if (previouslyFocused?.isConnected) {
+      window.setTimeout(() => previouslyFocused.focus(), 0);
+    }
+  }, [isOpen]);
 
   return (
     <Dialog.Root

--- a/src/components/NotificationsBell.tsx
+++ b/src/components/NotificationsBell.tsx
@@ -11,6 +11,7 @@ const NotificationsBell: React.FC = () => {
   const addNotification = useNotificationsStore((s) => s.addNotification);
   const [open, setOpen] = useState(false);
   const panelId = useId();
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
   const { isConnected } = useConnectionStatus();
 
   useEffect(() => {
@@ -40,6 +41,7 @@ const NotificationsBell: React.FC = () => {
       if (e.key === "Escape") {
         e.preventDefault();
         setOpen(false);
+        triggerRef.current?.focus();
       }
     };
     document.addEventListener("keydown", onKey);
@@ -53,6 +55,7 @@ const NotificationsBell: React.FC = () => {
     <div className="relative">
       <button
         type="button"
+        ref={triggerRef}
         className={`p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900 ${
           !isConnected ? 'opacity-50' : ''
         }`}
@@ -75,7 +78,13 @@ const NotificationsBell: React.FC = () => {
         )}
       </button>
       {open && (
-        <NotificationsPanel id={panelId} onClose={() => setOpen(false)} />
+        <NotificationsPanel
+          id={panelId}
+          onClose={() => {
+            setOpen(false);
+            triggerRef.current?.focus();
+          }}
+        />
       )}
     </div>
   );

--- a/src/components/NotificationsPanel.test.tsx
+++ b/src/components/NotificationsPanel.test.tsx
@@ -59,7 +59,13 @@ const mockNotifications: NotificationItem[] = [
   },
 ];
 
-const mockStore = {
+const mockStore: {
+  list: NotificationItem[];
+  loadingList: boolean;
+  errorList: string | null;
+  markAsRead: ReturnType<typeof vi.fn>;
+  fetchList: ReturnType<typeof vi.fn>;
+} = {
   list: [],
   loadingList: false,
   errorList: null,
@@ -96,6 +102,7 @@ describe('NotificationsPanel', () => {
       expect(panel).toHaveAttribute('id', 'notifications-panel');
       expect(panel).toHaveAttribute('aria-modal', 'false');
       expect(panel).toHaveAttribute('aria-labelledby', 'notifications-panel-title');
+      expect(panel).toHaveAttribute('aria-describedby', 'notifications-panel-description');
 
       const title = screen.getByRole('heading', { name: 'Notifications' });
       expect(title).toHaveAttribute('id', 'notifications-panel-title');
@@ -116,6 +123,35 @@ describe('NotificationsPanel', () => {
       fireEvent.click(closeButton);
 
       expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('focuses the close button when opened and closes on Escape', async () => {
+      const mockOnClose = vi.fn();
+      render(<NotificationsPanel {...defaultProps} onClose={mockOnClose} />);
+
+      const closeButton = screen.getByRole('button', { name: 'Close notifications' });
+      await waitFor(() => expect(closeButton).toHaveFocus());
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps Tab focus inside the panel', async () => {
+      mockStore.list = [mockNotifications[0]];
+      render(<NotificationsPanel {...defaultProps} />);
+
+      const closeButton = screen.getByRole('button', { name: 'Close notifications' });
+      const markAsReadButton = screen.getByRole('button', { name: /mark notification/i });
+
+      await waitFor(() => expect(closeButton).toHaveFocus());
+
+      markAsReadButton.focus();
+      fireEvent.keyDown(document, { key: 'Tab' });
+      expect(closeButton).toHaveFocus();
+
+      fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+      expect(markAsReadButton).toHaveFocus();
     });
   });
 

--- a/src/components/NotificationsPanel.tsx
+++ b/src/components/NotificationsPanel.tsx
@@ -1,13 +1,17 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useNotificationsStore } from '../store/useNotificationsStore';
 import { Clock, Check } from './icons';
 import { LoadingState, ErrorState, EmptyState } from './ui/StatusStates';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 const NotificationsPanel: React.FC<{ id: string; onClose: () => void }> = ({
   id,
   onClose,
 }) => {
   const titleId = `${id}-title`;
+  const descriptionId = `${id}-description`;
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const list = useNotificationsStore((s) => s.list);
   const loadingList = useNotificationsStore((s) => s.loadingList);
   const errorList = useNotificationsStore((s) => s.errorList);
@@ -22,12 +26,22 @@ const NotificationsPanel: React.FC<{ id: string; onClose: () => void }> = ({
     void fetchList();
   };
 
+  useFocusTrap(panelRef, {
+    active: true,
+    initialFocusRef: closeButtonRef,
+    onEscape: onClose,
+    restoreFocus: false,
+  });
+
   return (
     <div
       id={id}
+      ref={panelRef}
       role="dialog"
       aria-modal="false"
       aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+      tabIndex={-1}
       className="absolute right-0 mt-2 w-96 max-w-[calc(100vw-2rem)] bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg shadow-lg z-50"
     >
       <div className="p-4 border-b border-gray-100 dark:border-gray-800 flex items-center justify-between gap-2">
@@ -36,6 +50,7 @@ const NotificationsPanel: React.FC<{ id: string; onClose: () => void }> = ({
         </h2>
         <button
           type="button"
+          ref={closeButtonRef}
           onClick={onClose}
           aria-label="Close notifications"
           className="shrink-0 rounded-lg px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
@@ -43,6 +58,9 @@ const NotificationsPanel: React.FC<{ id: string; onClose: () => void }> = ({
           Close
         </button>
       </div>
+      <p id={descriptionId} className="sr-only">
+        Review notifications and mark unread items as read.
+      </p>
 
       <div className="max-h-80 overflow-auto min-h-[200px]">
         {loadingList && (

--- a/src/components/ProfileSettingsModal.test.tsx
+++ b/src/components/ProfileSettingsModal.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import ProfileSettingsModal from './ProfileSettingsModal';
+import { useProfileStore } from '../store/useProfileStore';
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../store/useProfileStore');
+
+const mockProfile = {
+  avatarUrl: null,
+  name: 'Ada Lovelace',
+  bio: 'First programmer',
+  twitterLink: 'https://x.com/ada',
+  streamerMode: false,
+};
+
+const mockStore = {
+  profile: mockProfile,
+  isLoading: false,
+  error: null,
+  loadProfile: vi.fn(),
+  saveProfile: vi.fn(),
+};
+
+describe('ProfileSettingsModal accessibility', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockStore.profile = mockProfile;
+    mockStore.isLoading = false;
+    mockStore.error = null;
+    mockStore.loadProfile = vi.fn().mockResolvedValue(undefined);
+    mockStore.saveProfile = vi.fn().mockResolvedValue(true);
+
+    vi.mocked(useProfileStore).mockImplementation((selector) => selector(mockStore));
+  });
+
+  it('renders dialog semantics with a label and description', async () => {
+    render(<ProfileSettingsModal onClose={vi.fn()} />);
+
+    await screen.findByLabelText('NAME');
+    const dialog = screen.getByRole('dialog', { name: /profile settings/i });
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-describedby', 'profile-settings-description');
+  });
+
+  it('focuses the first field and closes on Escape', async () => {
+    const onClose = vi.fn();
+    render(<ProfileSettingsModal onClose={onClose} />);
+
+    const nameInput = await screen.findByLabelText('NAME');
+    await waitFor(() => expect(nameInput).toHaveFocus());
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('traps focus inside the modal while open', async () => {
+    render(<ProfileSettingsModal onClose={vi.fn()} />);
+
+    const nameInput = await screen.findByLabelText('NAME');
+    const saveButton = screen.getByRole('button', { name: /save/i });
+
+    await waitFor(() => expect(nameInput).toHaveFocus());
+
+    saveButton.focus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(screen.getByRole('button', { name: /close profile settings/i })).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    expect(saveButton).toHaveFocus();
+  });
+
+  it('restores focus to the trigger after close', async () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Open profile';
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { unmount } = render(<ProfileSettingsModal onClose={vi.fn()} />);
+    await screen.findByRole('dialog', { name: /profile settings/i });
+
+    unmount();
+
+    expect(trigger).toHaveFocus();
+    trigger.remove();
+  });
+
+  it('uses a semantic switch button for streamer mode', async () => {
+    render(<ProfileSettingsModal onClose={vi.fn()} />);
+
+    const switchControl = await screen.findByRole('switch', { name: /streamer mode/i });
+    expect(switchControl.tagName).toBe('BUTTON');
+    expect(switchControl).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(switchControl);
+
+    expect(switchControl).toHaveAttribute('aria-checked', 'true');
+  });
+});

--- a/src/components/ProfileSettingsModal.tsx
+++ b/src/components/ProfileSettingsModal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import { toast } from "sonner";
 import { useProfileStore } from "../store/useProfileStore";
 import type { ProfileSettingsValues } from "../lib/profileApi";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 type Props = {
   onClose: () => void;
@@ -14,13 +15,6 @@ const DRAFT_KEY = "profile_settings_draft_v1";
 
 function cx(...classes: Array<string | false | null | undefined>) {
   return classes.filter(Boolean).join(" ");
-}
-
-function onEnterOrSpace(e: React.KeyboardEvent, fn: () => void) {
-  if (e.key === "Enter" || e.key === " ") {
-    e.preventDefault();
-    fn();
-  }
 }
 
 function isValidTwitterUrl(value: string) {
@@ -77,7 +71,7 @@ function ProfileSettingsForm({
   onClose: () => void;
   resolved: ProfileSettingsValues;
 }) {
-  const { saveProfile } = useProfileStore();
+  const saveProfile = useProfileStore((s) => s.saveProfile);
 
   const [avatarPreviewUrl, setAvatarPreviewUrl] = useState<string | null>(resolved.avatarUrl);
   const [name, setName] = useState(resolved.name);
@@ -95,20 +89,11 @@ function ProfileSettingsForm({
   const modalRef = useRef<HTMLDivElement | null>(null);
   const nameRef = useRef<HTMLInputElement | null>(null);
 
-  useEffect(() => {
-    nameRef.current?.focus();
-  }, []);
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClose();
-      }
-    };
-    window.addEventListener("keydown", onKey, true);
-    return () => window.removeEventListener("keydown", onKey, true);
-  }, [onClose]);
+  useFocusTrap(modalRef, {
+    active: true,
+    initialFocusRef: nameRef,
+    onEscape: onClose,
+  });
 
   useEffect(() => {
     const prev = document.body.style.overflow;
@@ -206,6 +191,8 @@ function ProfileSettingsForm({
           role="dialog"
           aria-modal="true"
           aria-labelledby="profile-settings-title"
+          aria-describedby="profile-settings-description"
+          tabIndex={-1}
           className={cx(
             "relative w-full max-w-3xl",
             "rounded-2xl bg-white dark:bg-gray-900",
@@ -235,6 +222,9 @@ function ProfileSettingsForm({
           </div>
 
           <div className="px-6 sm:px-8 py-6 overflow-y-auto max-h-[calc(85vh-72px)]">
+            <p id="profile-settings-description" className="sr-only">
+              Update your profile name, avatar, bio, links, and streamer mode.
+            </p>
             <div className="flex gap-6 items-center">
               <div className="h-24 w-24 rounded-2xl border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800 overflow-hidden flex items-center justify-center">
                 {avatarPreviewUrl ? (
@@ -288,8 +278,10 @@ function ProfileSettingsForm({
                 )}
                 placeholder="Your display name"
                 autoComplete="nickname"
+                aria-invalid={Boolean(errors.name)}
+                aria-describedby={errors.name ? "profile-display-name-error" : undefined}
               />
-              {errors.name && <p className="mt-2 text-xs text-red-600 dark:text-red-400">{errors.name}</p>}
+              {errors.name && <p id="profile-display-name-error" className="mt-2 text-xs text-red-600 dark:text-red-400">{errors.name}</p>}
             </div>
 
             <div className="mt-7">
@@ -312,14 +304,16 @@ function ProfileSettingsForm({
                   errors.bio && "border-red-500/60 focus-visible:ring-red-500/40"
                 )}
                 placeholder="Short description (max 100 chars)"
+                aria-invalid={Boolean(errors.bio)}
+                aria-describedby={errors.bio ? "profile-bio-error" : "profile-bio-hint"}
               />
               <div className="mt-2 flex items-center justify-between">
-                <p className="text-xs text-gray-500 dark:text-gray-400">Short description (max 100 chars)</p>
+                <p id="profile-bio-hint" className="text-xs text-gray-500 dark:text-gray-400">Short description (max 100 chars)</p>
                 <p className={cx("text-xs", bio.length > BIO_MAX ? "text-red-600 dark:text-red-400" : "text-gray-500 dark:text-gray-400")}>
                   {bio.length}/{BIO_MAX}
                 </p>
               </div>
-              {errors.bio && <p className="mt-2 text-xs text-red-600 dark:text-red-400">{errors.bio}</p>}
+              {errors.bio && <p id="profile-bio-error" className="mt-2 text-xs text-red-600 dark:text-red-400">{errors.bio}</p>}
             </div>
 
             <div className="mt-7">
@@ -341,10 +335,12 @@ function ProfileSettingsForm({
                   className="w-full bg-transparent text-sm text-gray-800 placeholder:text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD]/40 rounded-md dark:text-gray-100 dark:placeholder:text-gray-500"
                   placeholder="https://x.com/your_handle"
                   autoComplete="url"
+                  aria-invalid={Boolean(errors.twitterLink)}
+                  aria-describedby={errors.twitterLink ? "profile-twitter-link-error" : undefined}
                 />
               </div>
 
-              {errors.twitterLink && <p className="mt-2 text-xs text-red-600 dark:text-red-400">{errors.twitterLink}</p>}
+              {errors.twitterLink && <p id="profile-twitter-link-error" className="mt-2 text-xs text-red-600 dark:text-red-400">{errors.twitterLink}</p>}
             </div>
 
             <div className="mt-7 rounded-2xl bg-gray-50 border border-gray-200 px-5 py-4 dark:bg-gray-800 dark:border-gray-700">
@@ -356,13 +352,12 @@ function ProfileSettingsForm({
                   </p>
                 </div>
 
-                <div
+                <button
+                  type="button"
                   role="switch"
-                  tabIndex={0}
                   aria-checked={streamerMode}
                   aria-label="Streamer mode"
                   onClick={() => setStreamerMode((v) => !v)}
-                  onKeyDown={(e) => onEnterOrSpace(e, () => setStreamerMode((v) => !v))}
                   className={cx(
                     "relative inline-flex h-7 w-12 items-center rounded-full cursor-pointer transition shrink-0",
                     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800",
@@ -375,7 +370,7 @@ function ProfileSettingsForm({
                       streamerMode ? "left-6" : "left-1"
                     )}
                   />
-                </div>
+                </button>
               </div>
             </div>
 
@@ -405,7 +400,9 @@ function ProfileSettingsForm({
 }
 
 export default function ProfileSettingsModal({ onClose, initialValues }: Props) {
-  const { profile, isLoading, loadProfile } = useProfileStore();
+  const profile = useProfileStore((s) => s.profile);
+  const isLoading = useProfileStore((s) => s.isLoading);
+  const loadProfile = useProfileStore((s) => s.loadProfile);
   const [ready, setReady] = useState(false);
 
   useEffect(() => {

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,101 @@
+import { type RefObject, useEffect, useRef } from "react";
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+type UseFocusTrapOptions = {
+  active: boolean;
+  onEscape?: () => void;
+  initialFocusRef?: RefObject<HTMLElement | null>;
+  restoreFocus?: boolean;
+};
+
+function getFocusable(container: HTMLElement) {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (el) => !el.hasAttribute("disabled") && el.getAttribute("aria-hidden") !== "true",
+  );
+}
+
+export function useFocusTrap(
+  containerRef: RefObject<HTMLElement | null>,
+  {
+    active,
+    onEscape,
+    initialFocusRef,
+    restoreFocus = true,
+  }: UseFocusTrapOptions,
+) {
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+
+    previouslyFocusedRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    const focusable = getFocusable(container);
+    const initialTarget = initialFocusRef?.current ?? focusable[0] ?? container;
+    window.setTimeout(() => initialTarget.focus(), 0);
+
+    return () => {
+      if (!restoreFocus) return;
+      const previouslyFocused = previouslyFocusedRef.current;
+      if (previouslyFocused?.isConnected) previouslyFocused.focus();
+    };
+  }, [active, containerRef, initialFocusRef, restoreFocus]);
+
+  useEffect(() => {
+    if (!active) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      const container = containerRef.current;
+      if (!container) return;
+
+      if (event.key === "Escape" && onEscape) {
+        event.preventDefault();
+        onEscape();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const focusable = getFocusable(container);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        container.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const activeElement = document.activeElement;
+
+      if (!container.contains(activeElement)) {
+        event.preventDefault();
+        first.focus();
+        return;
+      }
+
+      if (event.shiftKey && activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
+  }, [active, containerRef, onEscape]);
+}


### PR DESCRIPTION
Description:
## Summary
- Added shared focus-trap behavior for modal/dialog-like surfaces.
- Hardened Profile Settings, End Round, and Notifications dialog semantics with labels/descriptions, Escape handling, Tab wrapping, and focus restoration.
- Replaced the custom clickable streamer-mode container with a semantic switch button.
- Added regression coverage for modal open/close behavior, focus cycling, Escape handling, and trigger focus restoration.

## Testing
- PASS: `npm run test:unit -- src/components/ProfileSettingsModal.test.tsx src/components/EndRoundModal.test.tsx src/components/NotificationsPanel.test.tsx`
- PASS: targeted ESLint for changed implementation/new test files
- NOTE: full `npm run build` remains blocked by existing unrelated TypeScript errors in socket/connection/store test files and older components.

## Related Issues
Closes #76 
