### PR TITLE
A11y: Standardize Focus Trap and Keyboard Closing Across Overlays

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { NavLink, Link } from "react-router-dom";
 import { useTheme } from "next-themes";
 import WalletConnect from "./WalletConnect";
@@ -6,6 +6,7 @@ import NotificationsBell from "./NotificationsBell";
 import Logo from "../assets/logo.svg";
 import ProfileSettingsModal from "./ProfileSettingsModal";
 import { useProfileStore } from "../store/useProfileStore";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 import { ConnectionIndicator } from "./ConnectionStatus";
 
 interface Routes {
@@ -18,6 +19,15 @@ const Header = () => {
   const { theme, setTheme } = useTheme();
   const [profileOpen, setProfileOpen] = useState(false);
   const profile = useProfileStore((s) => s.profile);
+  const mobileNavRef = useRef<HTMLDivElement | null>(null);
+  const mobileMenuButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useFocusTrap(mobileNavRef, {
+    active: open,
+    onEscape: () => setOpen(false),
+    restoreFocus: true,
+    restoreFocusRef: mobileMenuButtonRef,
+  });
 
   const toggleTheme = () => {
     setTheme(theme === "dark" ? "light" : "dark");
@@ -156,9 +166,11 @@ const Header = () => {
           </button>
           <button
             type="button"
+            ref={mobileMenuButtonRef}
             onClick={() => setOpen((v) => !v)}
             aria-expanded={open}
             aria-controls="mobile-primary-nav"
+            aria-haspopup="dialog"
             aria-label={open ? "Close menu" : "Open menu"}
             className="relative h-10 w-10 flex items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
           >
@@ -188,9 +200,12 @@ const Header = () => {
       {open && (
         <div
           id="mobile-primary-nav"
+          ref={mobileNavRef}
           className="md:hidden bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 px-4 pb-4 transition-colors"
-          role="region"
+          role="dialog"
+          aria-modal="true"
           aria-label="Mobile navigation"
+          tabIndex={-1}
         >
           <ul className="flex flex-col gap-2 pt-4">
             {routes.map(({ name, route }) => (

--- a/src/components/NotificationsPanel.test.tsx
+++ b/src/components/NotificationsPanel.test.tsx
@@ -100,7 +100,7 @@ describe('NotificationsPanel', () => {
 
       const panel = screen.getByRole('dialog');
       expect(panel).toHaveAttribute('id', 'notifications-panel');
-      expect(panel).toHaveAttribute('aria-modal', 'false');
+      expect(panel).toHaveAttribute('aria-modal', 'true');
       expect(panel).toHaveAttribute('aria-labelledby', 'notifications-panel-title');
       expect(panel).toHaveAttribute('aria-describedby', 'notifications-panel-description');
 
@@ -385,7 +385,7 @@ describe('NotificationsPanel', () => {
       render(<NotificationsPanel {...defaultProps} />);
 
       const dialog = screen.getByRole('dialog');
-      expect(dialog).toHaveAttribute('aria-modal', 'false');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
       expect(dialog).toHaveAttribute('aria-labelledby', 'notifications-panel-title');
     });
 

--- a/src/components/NotificationsPanel.tsx
+++ b/src/components/NotificationsPanel.tsx
@@ -38,7 +38,7 @@ const NotificationsPanel: React.FC<{ id: string; onClose: () => void }> = ({
       id={id}
       ref={panelRef}
       role="dialog"
-      aria-modal="false"
+      aria-modal="true"
       aria-labelledby={titleId}
       aria-describedby={descriptionId}
       tabIndex={-1}

--- a/src/components/__tests__/Header.a11y.test.tsx
+++ b/src/components/__tests__/Header.a11y.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi } from 'vitest';
 import Header from '../Header';
@@ -42,5 +42,20 @@ describe('Header accessibility', () => {
   it('exposes the home control with an accessible name', () => {
     renderHeader();
     expect(screen.getByRole('link', { name: /xelma home/i })).toBeInTheDocument();
+  });
+
+  it('traps focus in the mobile menu and closes on Escape', async () => {
+    renderHeader();
+
+    const toggleButton = screen.getByRole('button', { name: /open menu/i });
+    fireEvent.click(toggleButton);
+
+    const mobileNavDialog = await screen.findByRole('dialog', { name: /mobile navigation/i });
+    const firstNavLink = within(mobileNavDialog).getByRole('link', { name: /home/i });
+    await waitFor(() => expect(firstNavLink).toHaveFocus());
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() => expect(toggleButton).toHaveFocus());
+    expect(screen.queryByRole('dialog', { name: /mobile navigation/i })).not.toBeInTheDocument();
   });
 });

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -14,6 +14,7 @@ type UseFocusTrapOptions = {
   onEscape?: () => void;
   initialFocusRef?: RefObject<HTMLElement | null>;
   restoreFocus?: boolean;
+  restoreFocusRef?: RefObject<HTMLElement | null>;
 };
 
 function getFocusable(container: HTMLElement) {
@@ -29,6 +30,7 @@ export function useFocusTrap(
     onEscape,
     initialFocusRef,
     restoreFocus = true,
+    restoreFocusRef,
   }: UseFocusTrapOptions,
 ) {
   const previouslyFocusedRef = useRef<HTMLElement | null>(null);
@@ -49,7 +51,7 @@ export function useFocusTrap(
 
     return () => {
       if (!restoreFocus) return;
-      const previouslyFocused = previouslyFocusedRef.current;
+      const previouslyFocused = restoreFocusRef?.current ?? previouslyFocusedRef.current;
       if (previouslyFocused?.isConnected) previouslyFocused.focus();
     };
   }, [active, containerRef, initialFocusRef, restoreFocus]);


### PR DESCRIPTION
Closes #103

## ♿️ A11y: Standardize Focus Trap and Keyboard Closing Across Overlays

Implements consistent focus trapping, Escape-to-close, and focus restoration behavior across all overlay components, bringing the app into full keyboard accessibility compliance.

### Changes

**`src/components/Header.tsx`**
- Added `useFocusTrap` to the mobile navigation overlay
- Mobile menu now:
  - Traps `Tab` focus inside the open panel
  - Closes on `Escape`
  - Restores focus to the hamburger trigger button after close
- Added `role="dialog"`, `aria-modal="true"`, and `tabIndex={-1}` to the mobile overlay for correct dialog semantics

**`src/hooks/useFocusTrap.ts`**
- Extended hook with optional `restoreFocusRef` parameter
- Makes focus restoration more reliable by restoring to the actual opener trigger reference rather than relying on `document.activeElement`

**`src/components/NotificationsPanel.tsx`**
- Standardized dialog semantics with `aria-modal="true"` on the notification overlay

### Tests Updated

**`src/components/__tests__/Header.a11y.test.tsx`**
- Added coverage for mobile menu focus trapping
- Added coverage for Escape close behavior

**`src/components/NotificationsPanel.test.tsx`**
- Updated assertions to match new `aria-modal="true"` semantics

### Test Results
```
pnpm exec vitest run Header.a11y.test.tsx NotificationsPanel.test.tsx ✅
pnpm exec vitest run ProfileSettingsModal.test.tsx ✅
```
All targeted tests passed with no regressions.

### Acceptance Criteria
✅ Focus trap active in modal and panel contexts
✅ Escape closes all overlays consistently
✅ Focus returns to opener element on close
✅ No regressions in pointer interactions