### PR TITLE
perf(app): implement route-level code splitting with lazy loading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,43 +1,51 @@
+import { lazy, Suspense } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { Toaster } from 'sonner';
 import Navbar from './components/Navbar';
 import Landing from './pages/Landing';
-import Dashboard from './pages/Dashboard';
-import LegacyDashboard from './pages/LegacyDashboard';
-import Leaderboard from './components/Leaderboard';
-import LearnPage from './pages/Learn';
-import Connect from './pages/Connect';
-import Profile from './pages/Profile';
+import RouteFallback from './components/RouteFallback';
+import LazyBoundary from './components/LazyBoundary';
+
+const Dashboard = lazy(() => import('./pages/Dashboard'));
+const LegacyDashboard = lazy(() => import('./pages/LegacyDashboard'));
+const Leaderboard = lazy(() => import('./components/Leaderboard'));
+const LearnPage = lazy(() => import('./pages/Learn'));
+const Connect = lazy(() => import('./pages/Connect'));
+const Profile = lazy(() => import('./pages/Profile'));
 
 function App() {
   return (
     <div className="min-h-screen bg-[#0A0F1A] font-sans text-[#F3F4F6]">
       <Navbar />
-      <Routes>
-        <Route path="/" element={<Landing />} />
-        <Route path="/dashboard" element={<Dashboard />} />
-        <Route path="/play" element={<LegacyDashboard />} />
-        <Route path="/leaderboard" element={<Leaderboard />} />
-        <Route path="/learn" element={<LearnPage />} />
-        <Route path="/connect" element={<Connect />} />
-        <Route
-          path="/pools"
-          element={
-            <div className="xelma-grid-bg px-4 py-20 text-center text-xl font-bold text-gray-500">
-              Pools — Coming Soon
-            </div>
-          }
-        />
-        <Route
-          path="/tournament"
-          element={
-            <div className="xelma-grid-bg px-4 py-20 text-center text-xl font-bold text-gray-500">
-              Tournament — Coming Soon
-            </div>
-          }
-        />
-        <Route path="/profile" element={<Profile />} />
-      </Routes>
+      <LazyBoundary>
+        <Suspense fallback={<RouteFallback />}>
+          <Routes>
+            <Route path="/" element={<Landing />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/play" element={<LegacyDashboard />} />
+            <Route path="/leaderboard" element={<Leaderboard />} />
+            <Route path="/learn" element={<LearnPage />} />
+            <Route path="/connect" element={<Connect />} />
+            <Route
+              path="/pools"
+              element={
+                <div className="xelma-grid-bg px-4 py-20 text-center text-xl font-bold text-gray-500">
+                  Pools — Coming Soon
+                </div>
+              }
+            />
+            <Route
+              path="/tournament"
+              element={
+                <div className="xelma-grid-bg px-4 py-20 text-center text-xl font-bold text-gray-500">
+                  Tournament — Coming Soon
+                </div>
+              }
+            />
+            <Route path="/profile" element={<Profile />} />
+          </Routes>
+        </Suspense>
+      </LazyBoundary>
       <Toaster richColors position="top-center" theme="dark" />
     </div>
   );

--- a/src/components/LazyBoundary.tsx
+++ b/src/components/LazyBoundary.tsx
@@ -1,0 +1,45 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class LazyBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('[LazyBoundary] chunk load error:', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="xelma-grid-bg min-h-screen flex items-center justify-center">
+          <div className="glass-card rounded-xl p-8 flex flex-col items-center gap-4 max-w-sm w-full mx-4">
+            <p className="text-sm font-medium text-gray-400 text-center">
+              This page failed to load. Check your connection and try again.
+            </p>
+            <button
+              onClick={() => this.setState({ hasError: false })}
+              className="btn-primary rounded-lg px-6 py-2 text-sm font-semibold"
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default LazyBoundary;

--- a/src/components/RouteFallback.tsx
+++ b/src/components/RouteFallback.tsx
@@ -1,0 +1,14 @@
+const RouteFallback = () => (
+  <div className="xelma-grid-bg min-h-screen flex items-center justify-center">
+    <div className="flex flex-col items-center gap-4">
+      <div
+        className="h-10 w-10 rounded-full border-2 border-[#2C4BFD] border-t-transparent motion-safe:animate-spin"
+        role="status"
+        aria-label="Loading page"
+      />
+      <p className="text-sm font-medium text-gray-500 tracking-wide">Loading…</p>
+    </div>
+  </div>
+);
+
+export default RouteFallback;


### PR DESCRIPTION
Closes #137

## PR Description

The production JS bundle was approximately 1.5 MB on first load because all page components were statically imported and bundled together. This meant landing page visitors were downloading code for `/dashboard`, `/play`, `/leaderboard`, `/learn`, `/connect`, and `/profile` even if they never navigated to any of those routes.

This PR fixes that by converting all heavy route-level page imports in `src/App.tsx` to `React.lazy` dynamic imports. Vite automatically treats each dynamic import as a split point and emits a separate hashed chunk for each route in the production build. The browser only downloads a route's chunk when the user first navigates to it.

A `Suspense` boundary wraps the `<Routes>` tree so that a themed loading fallback (`RouteFallback`) is shown while a chunk is being downloaded. The fallback matches the existing dark theme - it uses the `xelma-grid-bg` background class and the brand blue (`#2C4BFD`) spinner. The spinner uses `motion-safe:animate-spin` (the Tailwind v4 canonical pattern), so it respects the user's OS-level `prefers-reduced-motion` preference.

A `LazyBoundary` error boundary wraps `Suspense`. This is required because `Suspense` on its own only handles the loading state - it does not catch chunk download failures. If a network error occurs or the CDN is serving stale chunk filenames after a deployment, React would otherwise throw an unhandled error and crash the whole app. `LazyBoundary` catches that with `getDerivedStateFromError` and shows a themed retry screen using the existing `glass-card` and `btn-primary` CSS classes.

`Navbar`, `Toaster`, and the `Landing` page are intentionally kept as eager imports. The navbar and toaster are rendered on every route and must stay mounted during transitions. Landing is the first thing every visitor sees, so lazy-loading it would produce a blank flash before the fallback even renders.

The `Suspense` and `LazyBoundary` boundaries are placed outside the `Navbar` and `Toaster` but inside the root `div`, so the shell remains stable and the nav stays interactive while page chunks load.

No changes were made to `vite.config.ts` - Vite handles dynamic import chunking automatically without any extra configuration.

---

## Changes Made

- **`src/App.tsx`** - Replaced 6 static page imports (`Dashboard`, `LegacyDashboard`, `Leaderboard`, `LearnPage`, `Connect`, `Profile`) with `React.lazy` dynamic imports declared at module top-level. Wrapped `<Routes>` in `<LazyBoundary><Suspense fallback={<RouteFallback />}>`. All route paths and their elements are unchanged.
- **`src/components/RouteFallback.tsx`** *(new)* - Stateless themed Suspense fallback. Uses `xelma-grid-bg`, brand blue spinner with `motion-safe:animate-spin`, `role="status"` and `aria-label` for accessibility.
- **`src/components/LazyBoundary.tsx`** *(new)* - Class-based error boundary. Declares `state: State = { hasError: false }` as a class property (TypeScript strict-mode compatible). Implements `getDerivedStateFromError` and `componentDidCatch`. Shows a themed retry screen with `glass-card` and `btn-primary` on chunk-load failure.

---

## Testing

```bash
# Lint
npm run lint

# Type check + production build (verifies chunk splitting in dist/assets/)
npm run build

# Unit tests
npm run test:unit
```

After running `npm run build`, the `dist/assets/` directory should show separate hashed JS files for each lazy route (e.g. `Dashboard-[hash].js`, `Learn-[hash].js`) alongside the reduced `index-[hash].js` main chunk.

Manual navigation test: visit each route in order (`/`, `/dashboard`, `/play`, `/leaderboard`, `/learn`, `/connect`, `/profile`) and confirm no blank screens or regressions.

---

## Scope Notes

- Frontend-only change.
- No backend changes.
- No contract logic changes.
- No new dependencies added.
- `vite.config.ts` was not modified - chunking is handled automatically.