### PR TITLE
feat(learn): rebrand learn page to match new fintech terminal design system

### DIFF
--- a/src/components/education/GuideCard.tsx
+++ b/src/components/education/GuideCard.tsx
@@ -11,12 +11,12 @@ export const GuideCard = ({ guide, className }: GuideCardProps) => {
     return (
         <article
             className={cn(
-                "group relative flex flex-col overflow-hidden rounded-2xl border border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:border-[#2C4BFD]/30 dark:hover:border-[#2C4BFD]/50",
+                "group relative flex flex-col overflow-hidden rounded-2xl glass-card transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_8px_32px_rgba(44,75,253,0.15)]",
                 className
             )}
             aria-labelledby={`guide-title-${guide.id}`}
         >
-            <div className="aspect-[16/9] w-full overflow-hidden bg-gray-100 dark:bg-gray-800">
+            <div className="aspect-[16/9] w-full overflow-hidden bg-[#111827]/80">
                 {guide.imageUrl ? (
                     <img
                         src={guide.imageUrl}
@@ -24,38 +24,38 @@ export const GuideCard = ({ guide, className }: GuideCardProps) => {
                         className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-110"
                     />
                 ) : (
-                    <div className="flex h-full w-full items-center justify-center bg-linear-to-br from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20">
-                        <BookOpen className="h-10 w-10 text-blue-500/50" aria-hidden />
+                    <div className="flex h-full w-full items-center justify-center bg-xelma-bg/60 border-b border-white/5">
+                        <BookOpen className="h-10 w-10 text-xelma-teal/40" aria-hidden />
                     </div>
                 )}
             </div>
 
             <div className="flex flex-1 flex-col p-5">
-                <div className="mb-3 flex items-center gap-2">
-                    <span className="inline-flex items-center rounded-full bg-blue-50 dark:bg-blue-900/30 px-2.5 py-0.5 text-xs font-medium text-blue-600 dark:text-blue-400">
+                <div className="mb-3 flex items-center gap-3">
+                    <span className="inline-flex items-center rounded-full bg-xelma-blue/10 border border-xelma-blue/20 px-2.5 py-0.5 text-xs font-semibold text-[#BEC7FE]">
                         {guide.category}
                     </span>
-                    <span className="inline-flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
-                        <Clock className="h-3 w-3 shrink-0" aria-hidden />
+                    <span className="inline-flex items-center gap-1 text-xs text-gray-400">
+                        <Clock className="h-3.5 w-3.5 shrink-0" aria-hidden />
                         {guide.readTime}
                     </span>
                 </div>
 
                 <h3
                     id={`guide-title-${guide.id}`}
-                    className="mb-2 text-xl font-bold text-gray-900 dark:text-white group-hover:text-[#2C4BFD] transition-colors"
+                    className="mb-2 text-xl font-bold text-white group-hover:text-xelma-teal transition-colors"
                 >
                     {guide.title}
                 </h3>
 
-                <p className="mb-4 line-clamp-2 text-sm text-gray-600 dark:text-gray-400">
+                <p className="mb-4 line-clamp-2 text-sm text-gray-400">
                     {guide.description}
                 </p>
 
                 <div className="mt-auto flex items-center justify-between gap-2">
                     <a
                         href={guide.externalLink || "#"}
-                        className="inline-flex items-center gap-1 text-sm font-semibold text-[#2C4BFD] hover:underline rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
+                        className="inline-flex items-center gap-1 text-sm font-semibold text-xelma-blue hover:text-xelma-teal hover:underline transition-colors rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-xelma-teal focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0F1A]"
                         aria-label={guide.externalLink ? `Read guide: ${guide.title} (opens in a new tab)` : `Read guide: ${guide.title}`}
                         target={guide.externalLink ? "_blank" : undefined}
                         rel={guide.externalLink ? "noopener noreferrer" : undefined}
@@ -63,7 +63,7 @@ export const GuideCard = ({ guide, className }: GuideCardProps) => {
                         Read Guide
                         <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-1" aria-hidden />
                     </a>
-                    <span className="text-[10px] uppercase tracking-wider text-gray-500 dark:text-gray-500 font-bold tabular-nums">
+                    <span className="text-[10px] uppercase tracking-wider text-gray-500 font-bold tabular-nums">
                         {new Date(guide.createdAt).toLocaleDateString(undefined, { month: 'short', year: 'numeric' })}
                     </span>
                 </div>

--- a/src/components/education/TipCard.tsx
+++ b/src/components/education/TipCard.tsx
@@ -11,28 +11,28 @@ export const TipCard = ({ tip, className }: TipCardProps) => {
     return (
         <article
             className={cn(
-                "relative overflow-hidden rounded-2xl bg-linear-to-br from-indigo-600 to-blue-700 p-6 text-white shadow-lg",
+                "relative overflow-hidden rounded-2xl glass-card accent-border-teal p-6 text-white shadow-[0_8px_32px_rgba(6,182,212,0.08)]",
                 className
             )}
             aria-labelledby={`tip-title-${tip.id}`}
         >
-            <div className="absolute -right-4 -top-4 text-white/10 pointer-events-none" aria-hidden>
+            <div className="absolute -right-4 -top-4 text-xelma-teal/10 pointer-events-none" aria-hidden>
                 <Sparkles size={120} />
             </div>
 
             <div className="relative flex flex-col gap-4">
-                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white/20 backdrop-blur-sm" aria-hidden>
-                    <Lightbulb className="h-6 w-6 text-yellow-300" />
+                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-xelma-teal/10 border border-xelma-teal/20 backdrop-blur-sm" aria-hidden>
+                    <Lightbulb className="h-6 w-6 text-xelma-teal-bright" />
                 </div>
 
                 <div>
                     <h3
                         id={`tip-title-${tip.id}`}
-                        className="text-lg font-bold text-white uppercase tracking-wider mb-1"
+                        className="text-xs font-bold text-xelma-teal uppercase tracking-wider mb-1"
                     >
                         {tip.title || "Daily Alpha Tip"}
                     </h3>
-                    <p className="text-xl font-medium leading-relaxed text-white">
+                    <p className="text-lg font-semibold leading-relaxed text-white">
                         <span className="sr-only">Tip: </span>
                         &ldquo;{tip.content}&rdquo;
                     </p>
@@ -40,7 +40,7 @@ export const TipCard = ({ tip, className }: TipCardProps) => {
 
                 {tip.category && (
                     <div className="mt-2">
-                        <span className="rounded-full bg-white/20 px-3 py-1 text-xs font-semibold backdrop-blur-sm">
+                        <span className="rounded-full bg-xelma-teal/10 border border-xelma-teal/20 px-3 py-1 text-xs font-semibold text-xelma-teal-bright backdrop-blur-sm">
                             #{tip.category}
                         </span>
                     </div>

--- a/src/components/ui/StatusStates.tsx
+++ b/src/components/ui/StatusStates.tsx
@@ -9,20 +9,20 @@ interface LoadingProps {
     dark?: boolean;
 }
 
-export const LoadingState = ({ message = "Loading content...", className, variant = "spinner", skeletonLines = 3, dark = false }: LoadingProps) => {
+export const LoadingState = ({ message = "Loading content...", className, variant = "spinner", skeletonLines = 3 }: LoadingProps) => {
     if (variant === "skeleton") {
         return (
             <div className={cn("space-y-4 p-4", className)}>
-                <div className={cn("h-4 rounded-full", dark ? "bg-white/10" : "bg-gray-200 dark:bg-gray-700")} style={{ width: "50%" }} />
+                <div className={cn("h-4 rounded-full animate-pulse bg-white/5 border border-white/5")} style={{ width: "50%" }} />
                 {Array.from({ length: skeletonLines }).map((_, i) => (
                     <div
                         key={i}
-                        className={cn("h-4 rounded animate-pulse", dark ? "bg-white/10" : "bg-gray-200 dark:bg-gray-700")}
+                        className={cn("h-4 rounded animate-pulse bg-white/5 border border-white/5")}
                         style={{ width: i === skeletonLines - 1 ? "75%" : "100%" }}
                     />
                 ))}
                 {message ? (
-                    <p className={cn("mt-2 text-sm", dark ? "text-white/70" : "text-gray-500 dark:text-gray-400")}>{message}</p>
+                    <p className="mt-2 text-sm text-gray-400">{message}</p>
                 ) : null}
             </div>
         );
@@ -30,8 +30,8 @@ export const LoadingState = ({ message = "Loading content...", className, varian
 
     return (
         <div className={cn("flex flex-col items-center justify-center p-12 text-center min-h-[200px]", className)}>
-            <Loader2 className={cn("h-10 w-10 animate-spin mb-4", dark ? "text-white" : "text-[#2C4BFD]")} />
-            <p className={cn("font-medium", dark ? "text-white/90" : "text-gray-500 dark:text-gray-400")}>{message}</p>
+            <Loader2 className={cn("h-10 w-10 animate-spin mb-4 text-xelma-blue")} />
+            <p className="font-medium text-gray-400">{message}</p>
         </div>
     );
 };
@@ -44,28 +44,19 @@ interface ErrorProps {
     variant?: "default" | "dark";
 }
 
-export const ErrorState = ({ message, onRetry, className, title = "Oops! Something went wrong", variant = "default" }: ErrorProps) => {
-    const isDark = variant === "dark";
+export const ErrorState = ({ message, onRetry, className, title = "Oops! Something went wrong" }: ErrorProps) => {
     return (
         <div className={cn(
-            "flex flex-col items-center justify-center p-12 text-center rounded-2xl min-h-[200px]",
-            isDark
-                ? "border border-red-500/30 bg-red-900/20 backdrop-blur-sm"
-                : "border border-red-100 bg-red-50 dark:bg-red-900/10 dark:border-red-900/20",
+            "flex flex-col items-center justify-center p-12 text-center rounded-2xl min-h-[200px] border border-red-500/20 bg-red-950/10 backdrop-blur-sm shadow-[0_0_24px_rgba(239,68,68,0.05)]",
             className
         )}>
-            <AlertCircle className={cn("h-10 w-10 mb-4", isDark ? "text-red-400" : "text-red-500")} />
-            <h3 className={cn("text-lg font-bold mb-2", isDark ? "text-white" : "text-gray-900 dark:text-white")}>{title}</h3>
-            <p className={cn("mb-6 max-w-md", isDark ? "text-red-200" : "text-red-600 dark:text-red-400")}>{message}</p>
+            <AlertCircle className="h-10 w-10 mb-4 text-red-400" />
+            <h3 className="text-lg font-bold mb-2 text-white">{title}</h3>
+            <p className="mb-6 max-w-md text-red-200/80 text-sm">{message}</p>
             {onRetry && (
                 <button
                     onClick={onRetry}
-                    className={cn(
-                        "inline-flex items-center gap-2 rounded-xl px-6 py-2.5 text-sm font-bold transition-all hover:scale-105 active:scale-95",
-                        isDark
-                            ? "bg-white text-gray-900 hover:bg-gray-100"
-                            : "bg-gray-900 dark:bg-white dark:text-gray-900 text-white"
-                    )}
+                    className="inline-flex items-center gap-2 rounded-xl bg-white text-gray-950 px-6 py-2.5 text-sm font-bold transition-all hover:scale-[1.02] hover:bg-gray-100 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0F1A]"
                 >
                     <RefreshCw className="h-4 w-4" />
                     Try Again
@@ -83,9 +74,9 @@ interface EmptyProps {
 }
 
 export const EmptyState = ({ title, message, icon, className }: EmptyProps) => (
-    <div className={cn("flex flex-col items-center justify-center p-12 text-center rounded-2xl border-2 border-dashed border-gray-200 dark:border-gray-800 min-h-[200px]", className)}>
-        {icon || <Inbox className="h-12 w-12 text-gray-300 dark:text-gray-700 mb-4" />}
-        <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">{title}</h3>
-        <p className="text-gray-500 dark:text-gray-400 max-w-sm">{message}</p>
+    <div className={cn("flex flex-col items-center justify-center p-12 text-center rounded-2xl border border-dashed border-white/10 bg-[#111827]/40 backdrop-blur-sm min-h-[200px]", className)}>
+        {icon || <Inbox className="h-12 w-12 text-gray-500 mb-4" />}
+        <h3 className="text-xl font-bold text-white mb-2">{title}</h3>
+        <p className="text-gray-400 max-w-sm text-sm">{message}</p>
     </div>
 );

--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -57,7 +57,7 @@ const LearnPage = () => {
 
     if (loading) {
         return (
-            <div className="container mx-auto px-4 py-12">
+            <div className="xelma-grid-bg min-h-screen relative flex items-center justify-center">
                 <LoadingState message="Fetching the latest alpha..." className="min-h-[60vh]" />
             </div>
         );
@@ -65,91 +65,96 @@ const LearnPage = () => {
 
     if (error) {
         return (
-            <div className="container mx-auto px-4 py-12">
-                <ErrorState message={error} onRetry={fetchData} className="min-h-[60vh]" />
+            <div className="xelma-grid-bg min-h-screen relative flex items-center justify-center px-4">
+                <ErrorState message={error} onRetry={fetchData} className="min-h-[60vh] max-w-lg w-full" />
             </div>
         );
     }
 
     return (
-        <div className="container mx-auto px-4 py-8 lg:py-12 max-w-7xl animate-in fade-in duration-700">
-            <header className="mb-12 text-center">
-                <div className="inline-flex items-center justify-center p-3 mb-4 rounded-2xl bg-blue-50 dark:bg-blue-900/20 text-[#2C4BFD]">
-                    <GraduationCap size={32} aria-hidden />
-                </div>
-                <h1 className="text-4xl lg:text-5xl font-black text-gray-900 dark:text-white mb-4 tracking-tight">
-                    Xelma Academy
-                </h1>
-                <p className="text-lg text-gray-700 dark:text-gray-300 max-w-2xl mx-auto">
-                    Master the art of prediction. Learn strategies, understand the Stellar ecosystem, and level up your trading game.
-                </p>
-            </header>
+        <div className="xelma-grid-bg min-h-screen relative text-[#F3F4F6] px-4 py-8 lg:py-12">
+            {/* Ambient glows */}
+            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,_rgba(44,75,253,0.15),_transparent_60%)]" aria-hidden />
+            <div className="pointer-events-none absolute -left-24 top-32 h-80 w-80 rounded-full bg-cyan-500/5 blur-3xl" aria-hidden />
+            <div className="pointer-events-none absolute -right-24 top-16 h-96 w-96 rounded-full bg-[#2C4BFD]/8 blur-3xl" aria-hidden />
 
-            <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
-                {/* Main Content: Guides */}
-                <div className="lg:col-span-8 space-y-8">
-                    <section aria-labelledby="learn-guides-heading">
-                        <div className="flex items-center gap-3 mb-8">
-                            <BookMarked className="text-[#2C4BFD] shrink-0" size={24} aria-hidden />
-                            <h2 id="learn-guides-heading" className="text-2xl font-bold text-gray-900 dark:text-white">
-                                Expert Guides
-                            </h2>
-                        </div>
+            <div className="relative mx-auto max-w-7xl animate-in fade-in duration-700">
+                <header className="mb-12 text-center">
+                    <div className="inline-flex items-center justify-center p-3 mb-4 rounded-2xl bg-xelma-blue/10 border border-xelma-blue/20 text-xelma-teal">
+                        <GraduationCap size={32} aria-hidden />
+                    </div>
+                    <h1 className="hero-headline text-4xl lg:text-5xl font-black mb-4 tracking-tight">
+                        Xelma <span className="hero-headline-accent">Academy</span>
+                    </h1>
+                    <p className="text-lg text-gray-400 max-w-2xl mx-auto">
+                        Master the art of prediction. Learn strategies, understand the Stellar ecosystem, and level up your trading game.
+                    </p>
+                </header>
 
-                        {guides.length > 0 ? (
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                                {guides.map((guide) => (
-                                    <GuideCard key={guide.id} guide={guide} />
-                                ))}
-                            </div>
-                        ) : (
-                            <EmptyState
-                                title="No guides available"
-                                message="Our experts are currently drafting new content. Check back soon for the latest strategies!"
-                                icon={<Telescope className="h-12 w-12 text-gray-300 dark:text-gray-700 mb-4" />}
-                                className="bg-gray-50 dark:bg-gray-900/50"
-                            />
-                        )}
-                    </section>
-                </div>
-
-                {/* Sidebar: Tip of the day */}
-                <aside className="lg:col-span-4" aria-label="Tips and community">
-                    <div className="sticky top-32 space-y-6">
-                        <section aria-labelledby="learn-tip-heading">
-                            <div className="flex items-center gap-3 mb-6">
-                                <h2 id="learn-tip-heading" className="text-xl font-bold text-gray-900 dark:text-white">
-                                    Quick Alpha
+                <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
+                    {/* Main Content: Guides */}
+                    <div className="lg:col-span-8 space-y-8">
+                        <section aria-labelledby="learn-guides-heading">
+                            <div className="flex items-center gap-3 mb-8">
+                                <BookMarked className="text-xelma-teal shrink-0" size={24} aria-hidden />
+                                <h2 id="learn-guides-heading" className="text-2xl font-bold text-white">
+                                    Expert Guides
                                 </h2>
                             </div>
 
-                            {tip ? (
-                                <TipCard tip={tip} />
+                            {guides.length > 0 ? (
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                                    {guides.map((guide) => (
+                                        <GuideCard key={guide.id} guide={guide} />
+                                    ))}
+                                </div>
                             ) : (
                                 <EmptyState
-                                    title="No tip today"
-                                    message="No specific tip for the moment. Keep your eyes on the chart!"
-                                    className="bg-blue-50/50 dark:bg-blue-900/5 py-8"
-                                    icon={<BookMarked className="h-8 w-8 text-blue-200 dark:text-blue-900/20 mb-3" />}
+                                    title="No guides available"
+                                    message="Our experts are currently drafting new content. Check back soon for the latest strategies!"
+                                    icon={<Telescope className="h-12 w-12 text-gray-600 mb-4" />}
                                 />
                             )}
                         </section>
-
-                        {/* Additional info box */}
-                        <div className="p-6 rounded-2xl border border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900">
-                            <h3 className="font-bold mb-2 text-gray-900 dark:text-white">Want to contribute?</h3>
-                            <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
-                                Are you an expert in Stellar or prediction markets? Share your knowledge with the community.
-                            </p>
-                            <button
-                                type="button"
-                                className="w-full py-2 px-4 rounded-xl text-sm font-bold border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
-                            >
-                                Apply as Educator
-                            </button>
-                        </div>
                     </div>
-                </aside>
+
+                    {/* Sidebar: Tip of the day */}
+                    <aside className="lg:col-span-4" aria-label="Tips and community">
+                        <div className="sticky top-32 space-y-6">
+                            <section aria-labelledby="learn-tip-heading">
+                                <div className="flex items-center gap-3 mb-6">
+                                    <h2 id="learn-tip-heading" className="text-xl font-bold text-white">
+                                        Quick Alpha
+                                    </h2>
+                                </div>
+
+                                {tip ? (
+                                    <TipCard tip={tip} />
+                                ) : (
+                                    <EmptyState
+                                        title="No tip today"
+                                        message="No specific tip for the moment. Keep your eyes on the chart!"
+                                        icon={<BookMarked className="h-8 w-8 text-gray-600 mb-3" />}
+                                    />
+                                )}
+                            </section>
+
+                            {/* Additional info box */}
+                            <div className="p-6 rounded-2xl glass-card">
+                                <h3 className="font-bold mb-2 text-white">Want to contribute?</h3>
+                                <p className="text-sm text-gray-400 mb-4">
+                                    Are you an expert in Stellar or prediction markets? Share your knowledge with the community.
+                                </p>
+                                <button
+                                    type="button"
+                                    className="btn-ghost w-full py-2.5 px-4 rounded-xl text-sm font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-xelma-blue focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0F1A]"
+                                >
+                                    Apply as Educator
+                                </button>
+                            </div>
+                        </div>
+                    </aside>
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
### Description
Rebrands the Xelma Academy (Learn) page and its associated components to match the new dark-mode fintech terminal design system of Xelma. This updates the cards, buttons, backgrounds, typography, and status indicators to use consistent premium styling tokens, glassmorphism, and accent colors.

Closes #124 

### Changes
* **Page Layout (`src/pages/Learn.tsx`)**:
  * Implemented the standard fintech grid overlay background (`xelma-grid-bg`) and added relative positioning with ambient linear-gradient radial glows.
  * Rebranded page title using `hero-headline` styling and custom gradient text (`hero-headline-accent`) on "Academy".
  * Replaced custom borders/backgrounds on the sidebar container with the `.glass-card` class and styled the "Apply as Educator" button using the `.btn-ghost` class.
* **Guide Card (`src/components/education/GuideCard.tsx`)**:
  * Applied the `.glass-card` class for a consistent glassmorphism feel, complete with hover lift-up translation and shadow transitions.
  * Upgraded category badges to `bg-xelma-blue/10 border border-xelma-blue/20 text-[#BEC7FE]` and action links to `text-xelma-blue hover:text-xelma-teal`.
* **Tip Card (`src/components/education/TipCard.tsx`)**:
  * Converted the main tip layout to use `.glass-card` with the `.accent-border-teal` style.
  * Restyled internal SVG icons, sparkles, titles, and tags using the `xelma-teal` and `xelma-teal-bright` design system color tokens.
* **Status States (`src/components/ui/StatusStates.tsx`)**:
  * **`LoadingState`**: Updated skeleton indicators to utilize `bg-white/5 border-white/5` pulse blocks and styled fallback spinners with the `text-xelma-blue` token.
  * **`ErrorState`**: Formatted error boxes with a soft red-tinted glass layout and refined Try Again actions.
  * **`EmptyState`**: Updated default borders to a subtle dashed glass overlay (`border-white/10 bg-[#111827]/40`).
  * Removed unused `dark` and `variant` parameter destructuring rules to satisfy linter constraints.

### Verification Results
* **Linter**: `npm run lint` completes with **0 errors**.
* **Build**: `npm run build` completes successfully.
* **Unit Tests**: `npm test` runs all **303 unit tests** successfully, including all coverage assertions in `Learn.test.tsx`.