### PR TITLE
Enable Leaderboard navigation link in Navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -18,7 +18,7 @@ interface NavLinkItem {
 
 const navLinks: NavLinkItem[] = [
   { label: 'Terminal', to: '/dashboard' },
-  { label: 'Leaderboard', to: '/leaderboard', disabled: true, tooltip: 'Coming Soon' },
+  { label: 'Leaderboard', to: '/leaderboard' },
   { label: 'Learn', to: '/learn' },
 ];
 


### PR DESCRIPTION
Fixed the Leaderboard navigation link in `src/components/Navbar.tsx` by removing the `disabled: true` and `tooltip: 'Coming Soon'` properties from the Leaderboard nav item. The active-route styling was already implemented in the component, so it will now show the highlighted state when on `/leaderboard`. The mobile layout is unaffected because the navbar nav links are hidden on mobile (`hidden md:flex`) and there is no mobile menu in this component.

Created branch `153-enable-leaderboard-navigation-link-in-navbar`, committed the change, and pushed to origin.

closes #153 