### PR TITLE
PR Description: Rebrand Leaderboard Page to Match Fintech Terminal Theme

### DIFF
--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -73,35 +73,35 @@ const Leaderboard = () => {
   const leaderboardRows = restUsers.map((user, index) => {
     const isCurrent = currentUser?.id === user.id;
     const rowClassName = clsx(
-      'flex flex-col items-center gap-3 md:flex-row md:justify-between md:gap-0 rounded-2xl p-4 shadow-sm transition-all duration-300',
+      'flex flex-col items-center gap-3 md:flex-row md:justify-between md:gap-0 rounded-2xl p-4 shadow-sm transition-all duration-300 group',
       isCurrent
-        ? 'bg-blue-50 dark:bg-blue-900/20 border border-blue-100 dark:border-blue-800'
-        : 'bg-white dark:bg-gray-800/50 border border-gray-100 dark:border-gray-700/50 hover:shadow-md hover:border-[#2C4BFD]/30 dark:hover:border-[#2C4BFD]/50 transform hover:-translate-y-0.5'
+        ? 'glass-card accent-border-teal bg-cyan-500/5'
+        : 'glass-card hover:bg-white/5 hover:border-cyan-500/30 hover:shadow-[0_0_15px_rgba(6,182,212,0.08)] transform hover:-translate-y-0.5'
     );
 
     return (
       <li key={user.id} className={rowClassName}>
         <div className="flex items-center gap-6 w-full justify-center md:justify-start">
-          <span className="text-gray-400 dark:text-gray-500 font-bold text-lg w-8 text-center tabular-nums">
+          <span className="text-cyan-400/60 font-bold text-lg w-8 text-center tabular-nums">
             {index + 4}
           </span>
-          <div className="w-12 h-12 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-700 border-2 border-transparent group-hover:border-[#2C4BFD]/20">
+          <div className="w-12 h-12 rounded-full overflow-hidden bg-slate-900 border border-white/10 group-hover:border-cyan-500/30 transition-colors">
             <img
               src={user.avatar}
               alt={user.name}
               className="w-full h-full object-cover"
             />
           </div>
-          <span className="font-bold text-[#292D32] dark:text-gray-200 text-lg">
+          <span className="font-bold text-white text-lg group-hover:text-cyan-200 transition-colors">
             {user.name}
           </span>
         </div>
-        <div className="text-center md:text-right w-full md:w-auto mt-2 md:mt-0 bg-blue-50 dark:bg-blue-900/20 px-4 py-2 rounded-xl">
-          <span className="font-bold text-[#2C4BFD] text-lg tabular-nums">
+        <div className="text-center md:text-right w-full md:w-auto mt-2 md:mt-0 bg-cyan-950/30 border border-cyan-500/20 px-4 py-2 rounded-xl shadow-[0_0_12px_rgba(6,182,212,0.05)]">
+          <span className="font-bold text-cyan-300 text-lg tabular-nums">
             {user.xlm.toLocaleString()}
           </span>
-          <span className="text-xs font-semibold text-blue-400 ml-1.5 uppercase tracking-wider">
-            XLM
+          <span className="text-xs font-semibold text-cyan-400 ml-1.5 uppercase tracking-wider">
+            vXLM
           </span>
         </div>
       </li>
@@ -110,158 +110,173 @@ const Leaderboard = () => {
 
   if (loading) {
     return (
-      <div className="w-full max-w-4xl mx-auto px-4 pb-12 pt-8">
-        <h1 className="text-3xl font-bold text-[#292D32] dark:text-white text-center mb-16 tracking-tight">
-          Leaderboard
-        </h1>
-        <LoadingState message="Loading leaderboard..." className="min-h-[40vh]" />
+      <div className="xelma-grid-bg min-h-screen text-[#F3F4F6] relative overflow-hidden px-4 pb-12 pt-8">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,_rgba(44,75,253,0.15),_transparent_60%)]" />
+        <div className="relative w-full max-w-4xl mx-auto">
+          <h1 className="hero-headline text-3xl sm:text-4xl font-extrabold text-white text-center mb-16 tracking-tight">
+            Leaderboard
+          </h1>
+          <LoadingState message="Loading leaderboard..." className="min-h-[40vh]" />
+        </div>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="w-full max-w-4xl mx-auto px-4 pb-12 pt-8">
-        <h1 className="text-3xl font-bold text-[#292D32] dark:text-white text-center mb-16 tracking-tight">
-          Leaderboard
-        </h1>
-        <ErrorState message={error} onRetry={fetchLeaderboard} className="min-h-[40vh]" />
+      <div className="xelma-grid-bg min-h-screen text-[#F3F4F6] relative overflow-hidden px-4 pb-12 pt-8">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,_rgba(44,75,253,0.15),_transparent_60%)]" />
+        <div className="relative w-full max-w-4xl mx-auto">
+          <h1 className="hero-headline text-3xl sm:text-4xl font-extrabold text-white text-center mb-16 tracking-tight">
+            Leaderboard
+          </h1>
+          <ErrorState message={error} onRetry={fetchLeaderboard} className="min-h-[40vh]" />
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="w-full max-w-4xl mx-auto px-4 pb-12 pt-8">
-      <h1 className="text-3xl font-bold text-[#292D32] dark:text-white text-center mb-16 tracking-tight">
-        Leaderboard
-      </h1>
+    <div className="xelma-grid-bg min-h-screen text-[#F3F4F6] relative overflow-hidden px-4 pb-12 pt-8">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,_rgba(44,75,253,0.15),_transparent_60%)]" />
+      <div className="pointer-events-none absolute -left-24 top-32 h-80 w-80 rounded-full bg-cyan-500/5 blur-3xl" />
+      <div className="pointer-events-none absolute -right-24 top-16 h-96 w-96 rounded-full bg-[#2C4BFD]/5 blur-3xl" />
 
-      {isWalletConnected && (
-        <div className="mb-8 rounded-3xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-5 shadow-sm lg:sticky lg:top-24 lg:z-20">
-          <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.32em] text-gray-500 dark:text-gray-400">
-                Current wallet summary
-              </p>
-              <p className="mt-2 text-lg font-bold text-[#292D32] dark:text-white">
-                {currentUser ? currentUser.name : walletShortAddress}
-              </p>
+      <div className="relative w-full max-w-4xl mx-auto">
+        <h1 className="hero-headline text-3xl sm:text-4xl font-extrabold text-white text-center mb-16 tracking-tight">
+          Leaderboard
+        </h1>
+
+        {isWalletConnected && (
+          <div className={clsx(
+            "mb-8 rounded-2xl glass-card p-5 lg:sticky lg:top-20 lg:z-20 transition-all duration-300",
+            currentUser ? "accent-border-teal" : ""
+          )}>
+            <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#22d3ee]">
+                  Current wallet summary
+                </p>
+                <p className="mt-2 text-lg font-bold text-white">
+                  {currentUser ? currentUser.name : walletShortAddress}
+                </p>
+              </div>
+              <div className="text-left md:text-right">
+                <p className="text-sm font-semibold text-cyan-200">
+                  {currentUser ? `Rank #${currentUserRank}` : 'Unranked'}
+                </p>
+                <p className="text-sm text-gray-400">
+                  {currentUser
+                    ? `${currentUser.xlm.toLocaleString()} vXLM`
+                    : 'Predictions will place you on the leaderboard.'}
+                </p>
+              </div>
             </div>
-            <div className="text-right">
-              <p className="text-sm font-semibold text-gray-700 dark:text-gray-200">
-                {currentUser ? `Rank #${currentUserRank}` : 'Unranked'}
-              </p>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                {currentUser
-                  ? `${currentUser.xlm.toLocaleString()} XLM`
-                  : 'Predictions will place you on the leaderboard.'}
-              </p>
+            <div className="mt-4 text-xs text-gray-400 border-t border-white/5 pt-3">
+              {currentUser
+                ? 'Keep making accurate predictions to move up the leaderboard.'
+                : 'Your connected wallet has not yet appeared on the leaderboard. Continue playing to earn a rank.'}
             </div>
           </div>
-          <div className="mt-4 text-sm text-gray-500 dark:text-gray-400">
-            {currentUser
-              ? 'Keep making accurate predictions to move up the leaderboard.'
-              : 'Your connected wallet has not yet appeared on the leaderboard. Continue playing to earn a rank.'}
-          </div>
+        )}
+
+        {/* Podium Section */}
+        <div className="flex flex-col md:flex-row items-end justify-center gap-6 mb-16 mt-24">
+          {/* Rank 2 (Silver) */}
+          {rank2 && (
+            <div className="order-2 md:order-1 flex flex-col items-center w-full md:w-1/3 group">
+              <div className="relative mb-4 transition-transform duration-300 md:group-hover:-translate-y-2">
+                <div className="w-24 h-24 rounded-full overflow-hidden border-4 border-[#C0C0C0] shadow-[0_0_20px_rgba(192,192,192,0.2)] z-10 relative bg-[#111827] ring-2 ring-[#C0C0C0]/25 ring-offset-2 ring-offset-[#0A0F1A]">
+                  <img
+                    src={rank2.avatar}
+                    alt={rank2.name}
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+                <div className="absolute -bottom-3 left-1/2 -translate-x-1/2 bg-gradient-to-r from-[#C0C0C0] to-[#E0E0E0] text-gray-900 text-sm font-extrabold py-1 px-3.5 rounded-full shadow-md z-20 whitespace-nowrap min-w-[32px] text-center border-2 border-[#0A0F1A]">
+                  #2
+                </div>
+              </div>
+              <p className="font-bold text-white text-lg mb-1 group-hover:text-cyan-200 transition-colors">
+                {rank2.name}
+              </p>
+              <p className="text-[#C0C0C0] font-bold text-sm bg-slate-500/10 border border-slate-500/20 px-3.5 py-1 rounded-full shadow-[0_0_10px_rgba(192,192,192,0.05)]">
+                {rank2.xlm.toLocaleString()} vXLM
+              </p>
+              <div className="w-full h-28 glass-card bg-gradient-to-t from-slate-500/15 via-slate-500/5 to-slate-900/40 rounded-t-2xl border-b-0 border-slate-500/20 mt-4 hidden md:block shadow-[0_-4px_20px_rgba(192,192,192,0.05)]"></div>
+            </div>
+          )}
+
+          {/* Rank 1 (Gold) */}
+          {rank1 && (
+            <div className="order-1 md:order-2 flex flex-col items-center w-full md:w-1/3 -mt-6 md:-mt-12 z-10 group">
+              <div className="relative mb-5 transition-transform duration-300 md:group-hover:-translate-y-2">
+                <div className="w-32 h-32 rounded-full overflow-hidden border-[5px] border-[#FFD700] shadow-[0_0_30px_rgba(255,215,0,0.3)] z-10 relative bg-[#111827] ring-2 ring-[#FFD700]/30 ring-offset-2 ring-offset-[#0A0F1A]">
+                  <img
+                    src={rank1.avatar}
+                    alt={rank1.name}
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+                <div className="absolute -bottom-4 left-1/2 -translate-x-1/2 bg-gradient-to-r from-[#FFD700] to-[#FDB931] text-gray-900 text-base font-extrabold py-1.5 px-4.5 rounded-full shadow-lg z-20 whitespace-nowrap min-w-[40px] text-center border-2 border-[#0A0F1A]">
+                  #1
+                </div>
+                <div
+                  className="absolute -top-8 left-1/2 -translate-x-1/2 text-4xl animate-bounce drop-shadow-[0_0_10px_rgba(255,215,0,0.8)]"
+                  aria-hidden="true"
+                >
+                  👑
+                </div>
+              </div>
+              <p className="font-bold text-white text-2xl mb-1 group-hover:text-cyan-200 transition-colors">
+                {rank1.name}
+              </p>
+              <p className="text-[#FDB931] font-extrabold text-base bg-amber-500/15 border border-amber-500/25 px-4 py-1.5 rounded-full shadow-md shadow-amber-500/5">
+                {rank1.xlm.toLocaleString()} vXLM
+              </p>
+              <div className="w-full h-36 glass-card bg-gradient-to-t from-amber-500/20 via-amber-500/5 to-slate-900/40 rounded-t-2xl border-b-0 border-amber-500/20 mt-4 hidden md:block shadow-[0_-4px_20px_rgba(251,191,36,0.05)]"></div>
+            </div>
+          )}
+
+          {/* Rank 3 (Bronze) */}
+          {rank3 && (
+            <div className="order-3 md:order-3 flex flex-col items-center w-full md:w-1/3 group">
+              <div className="relative mb-4 transition-transform duration-300 md:group-hover:-translate-y-2">
+                <div className="w-24 h-24 rounded-full overflow-hidden border-4 border-[#CD7F32] shadow-[0_0_20px_rgba(205,127,50,0.2)] z-10 relative bg-[#111827] ring-2 ring-[#CD7F32]/25 ring-offset-2 ring-offset-[#0A0F1A]">
+                  <img
+                    src={rank3.avatar}
+                    alt={rank3.name}
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+                <div className="absolute -bottom-3 left-1/2 -translate-x-1/2 bg-gradient-to-r from-[#CD7F32] to-[#B87333] text-white text-sm font-extrabold py-1 px-3.5 rounded-full shadow-md z-20 whitespace-nowrap min-w-[32px] text-center border-2 border-[#0A0F1A]">
+                  #3
+                </div>
+              </div>
+              <p className="font-bold text-white text-lg mb-1 group-hover:text-cyan-200 transition-colors">
+                {rank3.name}
+              </p>
+              <p className="text-[#CD7F32] font-bold text-sm bg-amber-700/10 border border-amber-700/20 px-3.5 py-1 rounded-full shadow-[0_0_10px_rgba(205,127,50,0.05)]">
+                {rank3.xlm.toLocaleString()} vXLM
+              </p>
+              <div className="w-full h-20 glass-card bg-gradient-to-t from-amber-800/15 via-amber-800/5 to-slate-900/40 rounded-t-2xl border-b-0 border-amber-800/20 mt-4 hidden md:block shadow-[0_-4px_20px_rgba(180,83,9,0.05)]"></div>
+            </div>
+          )}
         </div>
-      )}
 
-      {/* Podium Section */}
-      <div className="flex flex-col md:flex-row items-end justify-center gap-6 mb-16 mt-24">
-        {/* Rank 2 (Silver) */}
-        {rank2 && (
-          <div className="order-2 md:order-1 flex flex-col items-center w-full md:w-1/3 group">
-            <div className="relative mb-4 transition-transform duration-300 md:group-hover:-translate-y-2">
-              <div className="w-24 h-24 rounded-full overflow-hidden border-4 border-[#C0C0C0] shadow-[0_0_20px_rgba(192,192,192,0.4)] z-10 relative bg-white dark:bg-gray-800">
-                <img
-                  src={rank2.avatar}
-                  alt={rank2.name}
-                  className="w-full h-full object-cover"
-                />
-              </div>
-              <div className="absolute -bottom-3 left-1/2 -translate-x-1/2 bg-linear-to-r from-[#C0C0C0] to-[#E0E0E0] text-gray-800 text-sm font-bold py-1 px-3 rounded-full shadow-md z-20 whitespace-nowrap min-w-[32px] text-center border-2 border-white dark:border-gray-900">
-                #2
-              </div>
-            </div>
-            <p className="font-bold text-[#292D32] dark:text-white text-lg mb-1">
-              {rank2.name}
-            </p>
-            <p className="text-[#C0C0C0] font-bold text-base bg-[#C0C0C0]/10 px-3 py-1 rounded-full">
-              {rank2.xlm.toLocaleString()} XLM
-            </p>
-            <div className="w-full h-24 bg-linear-to-t from-[#C0C0C0]/20 to-transparent rounded-t-2xl mt-4 hidden md:block"></div>
-          </div>
-        )}
-
-        {/* Rank 1 (Gold) */}
-        {rank1 && (
-          <div className="order-1 md:order-2 flex flex-col items-center w-full md:w-1/3 -mt-6 md:-mt-12 z-10 group">
-            <div className="relative mb-5 transition-transform duration-300 md:group-hover:-translate-y-2">
-              <div className="w-32 h-32 rounded-full overflow-hidden border-[5px] border-[#FFD700] shadow-[0_0_30px_rgba(255,215,0,0.5)] z-10 relative bg-white dark:bg-gray-800 ring-2 ring-[#FFD700]/50 ring-offset-2 dark:ring-offset-gray-900">
-                <img
-                  src={rank1.avatar}
-                  alt={rank1.name}
-                  className="w-full h-full object-cover"
-                />
-              </div>
-              <div className="absolute -bottom-4 left-1/2 -translate-x-1/2 bg-linear-to-r from-[#FFD700] to-[#FDB931] text-gray-900 text-base font-extrabold py-1.5 px-4 rounded-full shadow-lg z-20 whitespace-nowrap min-w-[40px] text-center border-2 border-white dark:border-gray-900">
-                #1
-              </div>
-              <div
-                className="absolute -top-8 left-1/2 -translate-x-1/2 text-4xl animate-bounce drop-shadow-[0_0_10px_rgba(255,215,0,0.8)]"
-                aria-hidden="true"
-              >
-                👑
-              </div>
-            </div>
-            <p className="font-bold text-[#292D32] dark:text-white text-2xl mb-1">
-              {rank1.name}
-            </p>
-            <p className="text-[#FDB931] font-extrabold text-xl bg-[#FFD700]/10 px-4 py-1.5 rounded-full shadow-sm shadow-[#FFD700]/10">
-              {rank1.xlm.toLocaleString()} XLM
-            </p>
-            <div className="w-full h-40 bg-linear-to-t from-[#FFD700]/25 to-transparent rounded-t-2xl mt-4 hidden md:block"></div>
-          </div>
-        )}
-
-        {/* Rank 3 (Bronze) */}
-        {rank3 && (
-          <div className="order-3 md:order-3 flex flex-col items-center w-full md:w-1/3 group">
-            <div className="relative mb-4 transition-transform duration-300 md:group-hover:-translate-y-2">
-              <div className="w-24 h-24 rounded-full overflow-hidden border-4 border-[#CD7F32] shadow-[0_0_20px_rgba(205,127,50,0.4)] z-10 relative bg-white dark:bg-gray-800">
-                <img
-                  src={rank3.avatar}
-                  alt={rank3.name}
-                  className="w-full h-full object-cover"
-                />
-              </div>
-              <div className="absolute -bottom-3 left-1/2 -translate-x-1/2 bg-linear-to-r from-[#CD7F32] to-[#B87333] text-white text-sm font-bold py-1 px-3 rounded-full shadow-md z-20 whitespace-nowrap min-w-[32px] text-center border-2 border-white dark:border-gray-900">
-                #3
-              </div>
-            </div>
-            <p className="font-bold text-[#292D32] dark:text-white text-lg mb-1">
-              {rank3.name}
-            </p>
-            <p className="text-[#CD7F32] font-bold text-base bg-[#CD7F32]/10 px-3 py-1 rounded-full">
-              {rank3.xlm.toLocaleString()} XLM
-            </p>
-            <div className="w-full h-20 bg-linear-to-t from-[#CD7F32]/20 to-transparent rounded-t-2xl mt-4 hidden md:block"></div>
-          </div>
-        )}
+        {/* Ranked List */}
+        {restUsers.length > 0 ? (
+          <ul className="space-y-4 max-w-3xl mx-auto">
+            {leaderboardRows}
+          </ul>
+        ) : sortedUsers.length === 0 ? (
+          <EmptyState
+            title="No leaderboard data yet"
+            message="Be the first to make a prediction and climb to the top!"
+            className="max-w-xl mx-auto"
+          />
+        ) : null}
       </div>
-
-      {/* Ranked List */}
-      {restUsers.length > 0 ? (
-        <ul className="space-y-4 max-w-3xl mx-auto">
-          {leaderboardRows}
-        </ul>
-      ) : sortedUsers.length === 0 ? (
-        <EmptyState
-          title="No leaderboard data yet"
-          message="Be the first to make a prediction and climb to the top!"
-          className="max-w-xl mx-auto"
-        />
-      ) : null}
     </div>
   );
 };

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -19,7 +19,7 @@ interface NavLinkItem {
 
 const navLinks: NavLinkItem[] = [
   { label: 'Terminal', to: '/dashboard' },
-  { label: 'Leaderboard', to: '/leaderboard', disabled: true, tooltip: 'Coming Soon' },
+  { label: 'Leaderboard', to: '/leaderboard' },
   { label: 'Learn', to: '/learn' },
   { label: 'Profile', to: '/profile' },
 ];

--- a/src/components/education/GuideCard.tsx
+++ b/src/components/education/GuideCard.tsx
@@ -55,7 +55,7 @@ export const GuideCard = ({ guide, className }: GuideCardProps) => {
                 <div className="mt-auto flex items-center justify-between gap-2">
                     <a
                         href={guide.externalLink || "#"}
-                        className="inline-flex items-center gap-1 text-sm font-semibold text-xelma-blue hover:text-xelma-teal hover:underline transition-colors rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-xelma-teal focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0F1A]"
+                        className="inline-flex items-center gap-1 text-sm font-semibold text-cyan-400 hover:text-cyan-300 hover:underline transition-colors rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-xelma-teal focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0F1A]"
                         aria-label={guide.externalLink ? `Read guide: ${guide.title} (opens in a new tab)` : `Read guide: ${guide.title}`}
                         target={guide.externalLink ? "_blank" : undefined}
                         rel={guide.externalLink ? "noopener noreferrer" : undefined}

--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -57,16 +57,18 @@ const LearnPage = () => {
 
     if (loading) {
         return (
-            <div className="xelma-grid-bg min-h-screen relative flex items-center justify-center">
-                <LoadingState message="Fetching the latest alpha..." className="min-h-[60vh]" />
+            <div className="xelma-grid-bg min-h-screen relative flex items-center justify-center overflow-hidden">
+                <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,_rgba(44,75,253,0.15),_transparent_60%)]" aria-hidden />
+                <LoadingState message="Fetching the latest alpha..." className="min-h-[60vh] relative z-10" />
             </div>
         );
     }
 
     if (error) {
         return (
-            <div className="xelma-grid-bg min-h-screen relative flex items-center justify-center px-4">
-                <ErrorState message={error} onRetry={fetchData} className="min-h-[60vh] max-w-lg w-full" />
+            <div className="xelma-grid-bg min-h-screen relative flex items-center justify-center px-4 overflow-hidden">
+                <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,_rgba(44,75,253,0.15),_transparent_60%)]" aria-hidden />
+                <ErrorState message={error} onRetry={fetchData} className="min-h-[60vh] max-w-lg w-full relative z-10" />
             </div>
         );
     }
@@ -147,7 +149,7 @@ const LearnPage = () => {
                                 </p>
                                 <button
                                     type="button"
-                                    className="btn-ghost w-full py-2.5 px-4 rounded-xl text-sm font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-xelma-blue focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0F1A]"
+                                    className="btn-ghost w-full py-2.5 px-4 rounded-xl text-sm font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-xelma-teal focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0F1A]"
                                 >
                                     Apply as Educator
                                 </button>


### PR DESCRIPTION

Category
UI/UX / Frontend Enhancement

Linked Issue
Closes #123

Description
This PR upgrades the /leaderboard page to align with the new dark fintech terminal design system established in the Landing (/) and Dashboard (/dashboard) views. Previously, the Leaderboard route was disabled and retained an older light/blue aesthetic.

Key Enhancements
Route Enablement & Navigation:

Enabled the /leaderboard link in Navbar.tsx for both the desktop header menu and the mobile menu drawer.
Removed the "Coming Soon" tooltip and disabled state constraints.
Visual Consistency & Background Branding:

Integrated the .xelma-grid-bg backdrop layout with grid overlays, top radial gradient masks, and glowing ambient background blur nodes (bg-cyan-500/5 and bg-[#2C4BFD]/5).
Wrapped the primary layout, including the loading and error states, inside the same grid layout to ensure consistency during page transitions.
Updated the header text style to match the modern .hero-headline theme.
Current Wallet Summary Card:

Refactored the summary container to use glass-card styling with backdrop-filter.
Highlighted the summary block with a cyan/teal glow border (.accent-border-teal) if the user has an active rank on the leaderboard.
Refined Podium UX:

Upgraded Silver, Gold, and Bronze pedestals to glassmorphic columns with rank-themed gradient glows.
Enhanced the podium avatar containers with dual-ring glowing borders and dark offsets (ring-offset-[#0A0F1A]) to blend smoothly with the background.
Ranked User List Rows:

Applied .glass-card backings with scale transitions (hover:-translate-y-0.5) on row hover.
Highlighted the active user's row using .accent-border-teal and subtle teal-cyan background backing.
Improved accessibility and readability by migrating gray text elements to high-contrast colors (text-white, text-cyan-200, text-cyan-400, text-cyan-300).
Acceptance Criteria Checklist
 Leaderboard matches new design tokens (Background #0A0F1A, .glass-card, blue/teal accents)
 Navbar Leaderboard link enabled
 Dark theme contrast passes basic accessibility (A11y) guidelines
 Mobile responsive layout verified (stacked columns, scroll layout)
 Code compiles, builds, and passes ESLint check with 0 errors
 
 Closes #171 