### PR TITLE
Surface prediction history

### DIFF
--- a/src/pages/Dashboard.terminal.test.tsx
+++ b/src/pages/Dashboard.terminal.test.tsx
@@ -19,6 +19,7 @@ vi.mock('../components/PriceChart', () => ({
 vi.mock('../lib/api-client', () => ({
   predictionsApi: {
     submit: vi.fn(),
+    getUserHistory: vi.fn().mockResolvedValue([]),
   },
 }));
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef } from "react";
 import PriceChart from "../components/PriceChart";
 import PredictionCard from "../components/PredictionCard";
+import PredictionHistory from "../components/PredictionHistory";
 import type { PredictionData } from "../components/PredictionControls";
 import BetModal from "../components/BetModal";
 import { useRoundStore } from "../store/useRoundStore";
@@ -13,6 +14,7 @@ const Dashboard = () => {
   const isWalletConnecting = useWalletStore(
     (s) => s.status === "connecting" || s.status === "checking"
   );
+  const publicKey = useWalletStore((s) => s.publicKey);
   const [isBetModalOpen, setIsBetModalOpen] = useState(false);
   const [pendingPrediction, setPendingPrediction] = useState<PredictionData | null>(null);
   const timeoutRef = useRef<number | null>(null);
@@ -66,6 +68,7 @@ const Dashboard = () => {
             <div className="min-h-[350px] bg-white dark:bg-gray-800 p-6 shadow-sm rounded-xl border border-gray-100 dark:border-gray-700">
               <PriceChart height={280} />
             </div>
+            <PredictionHistory userId={publicKey} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
Imported PredictionHistory, added publicKey from the wallet store, and rendered <PredictionHistory userId={publicKey} /> below the PriceChart in the right column. This reuses the existing component, which already handles disconnected wallet (shows "Connect your wallet" empty state), loading (skeleton), error (retry), empty ("No predictions yet"), and populated list states. src/pages/Dashboard.terminal.test.tsx: Added getUserHistory: vi.fn().mockResolvedValue([]) to the predictionsApi mock so the existing tests work with the new component mounted. 
Closed #164