### PR TITLE
Feature/pools page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ const Leaderboard = lazy(() => import('./components/Leaderboard'));
 const LearnPage = lazy(() => import('./pages/Learn'));
 const Connect = lazy(() => import('./pages/Connect'));
 const Profile = lazy(() => import('./pages/Profile'));
+const Pools = lazy(() => import('./pages/Pools'));
 
 function App() {
   return (
@@ -28,14 +29,7 @@ function App() {
             <Route path="/leaderboard" element={<Leaderboard />} />
             <Route path="/learn" element={<LearnPage />} />
             <Route path="/connect" element={<Connect />} />
-            <Route
-              path="/pools"
-              element={
-                <div className="xelma-grid-bg px-4 py-20 text-center text-xl font-bold text-gray-500">
-                  Pools — Coming Soon
-                </div>
-              }
-            />
+            <Route path="/pools" element={<Pools />} />
             <Route
               path="/tournament"
               element={

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -19,6 +19,7 @@ interface NavLinkItem {
 
 const navLinks: NavLinkItem[] = [
   { label: 'Terminal', to: '/dashboard' },
+  { label: 'Pools', to: '/pools' },
   { label: 'Leaderboard', to: '/leaderboard' },
   { label: 'Learn', to: '/learn' },
   { label: 'Profile', to: '/profile' },

--- a/src/components/StatsCard.tsx
+++ b/src/components/StatsCard.tsx
@@ -1,13 +1,48 @@
 // ISSUE: Replace mock stats with live API call to backend /api/stats
 // ISSUE: Add XP and rank progression system UI
 
+import { useState } from 'react';
 import type { MockUserStats } from '../types';
+import { useWalletStore, selectIsWalletConnected } from '../store/useWalletStore';
+import { claim_winnings } from '../lib/xelma-contract';
+import { toast } from 'sonner';
 
 interface StatsCardProps {
   stats: MockUserStats;
 }
 
 export default function StatsCard({ stats }: StatsCardProps) {
+  const isWalletConnected = useWalletStore(selectIsWalletConnected);
+  const publicKey = useWalletStore((s) => s.publicKey);
+  const checkConnection = useWalletStore((s) => s.checkConnection);
+  
+  const [isClaiming, setIsClaiming] = useState(false);
+
+  const pendingWinnings = stats.pendingWinnings || 0;
+  const canClaim = isWalletConnected && pendingWinnings > 0 && !isClaiming;
+
+  const handleClaim = async () => {
+    if (!canClaim || !publicKey) return;
+    
+    try {
+      setIsClaiming(true);
+      toast.loading('Claiming rewards...', { id: 'claim-rewards' });
+      
+      const result = await claim_winnings(publicKey);
+      
+      toast.success(`Successfully claimed rewards! Tx: ${result.txHash.slice(0, 8)}...`, { id: 'claim-rewards' });
+      
+      // Refresh wallet balance/state
+      await checkConnection();
+    } catch (error) {
+      console.error('Claim failed:', error);
+      const msg = error instanceof Error ? error.message : 'Failed to claim rewards.';
+      toast.error(msg, { id: 'claim-rewards' });
+    } finally {
+      setIsClaiming(false);
+    }
+  };
+
   return (
     <section className="glass-card rounded-2xl p-5" aria-labelledby="your-stats-title">
       <h2 id="your-stats-title" className="text-lg font-bold text-white">
@@ -49,17 +84,32 @@ export default function StatsCard({ stats }: StatsCardProps) {
           <dt className="text-sm text-gray-400">Experience</dt>
           <dd className="font-mono text-sm text-gray-300">{stats.xp} XP</dd>
         </div>
+        
+        {pendingWinnings > 0 && (
+          <div className="flex items-center justify-between border-t border-white/10 pt-4">
+            <dt className="text-sm text-gray-400 text-amber-200">Pending Winnings</dt>
+            <dd className="font-mono text-sm font-bold text-amber-300">
+              {pendingWinnings.toLocaleString()} vXLM
+            </dd>
+          </div>
+        )}
       </dl>
 
       <button
         type="button"
-        disabled
-        title="No pending rewards"
-        className="mt-6 w-full cursor-not-allowed rounded-xl border border-white/10 bg-white/5 py-3 text-sm font-semibold text-gray-500"
+        disabled={!canClaim}
+        onClick={handleClaim}
+        title={!isWalletConnected ? "Connect wallet to claim" : pendingWinnings === 0 ? "No pending rewards" : "Claim your rewards"}
+        className={`mt-6 w-full rounded-xl border py-3 text-sm font-semibold transition-colors
+          ${canClaim 
+            ? 'border-amber-400/50 bg-amber-500/20 text-amber-200 hover:bg-amber-500/30' 
+            : 'cursor-not-allowed border-white/10 bg-white/5 text-gray-500'}`}
       >
-        Claim Rewards
+        {isClaiming ? 'Claiming...' : 'Claim Rewards'}
       </button>
-      <p className="mt-2 text-center text-xs text-gray-600">No pending rewards</p>
+      <p className="mt-2 text-center text-xs text-gray-600">
+        {!isWalletConnected ? "Connect wallet to claim" : pendingWinnings === 0 ? "No pending rewards" : "Ready to claim"}
+      </p>
     </section>
   );
 }

--- a/src/lib/xelma-contract.ts
+++ b/src/lib/xelma-contract.ts
@@ -191,3 +191,18 @@ export async function place_precision_prediction(
 
   return executeContractCall(userAddress, 'place_precision_prediction', args, onStatus);
 }
+
+/**
+ * Claims pending winnings for the user.
+ * @param userAddress The public key of the user.
+ */
+export async function claim_winnings(
+  userAddress: string,
+  onStatus?: (status: 'preparing' | 'signing' | 'submitting') => void
+): Promise<ContractTransactionResult> {
+  const args = [
+    new Address(userAddress).toScVal(),
+  ];
+
+  return executeContractCall(userAddress, 'claim_winnings', args, onStatus);
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,9 +3,12 @@ import PriceChart from "../components/PriceChart";
 import PredictionCard from "../components/PredictionCard";
 import type { PredictionData } from "../components/PredictionControls";
 import BetModal from "../components/BetModal";
+import EndRoundModal from "../components/EndRoundModal";
 import { useRoundStore } from "../store/useRoundStore";
+import type { Round } from "../lib/api-client";
 import { useWalletStore, selectIsWalletConnected } from "../store/useWalletStore";
 import { Link } from "react-router-dom";
+
 
 const Dashboard = () => {
   const isRoundActive = useRoundStore((state) => state.isRoundActive);
@@ -13,6 +16,8 @@ const Dashboard = () => {
   const isWalletConnecting = useWalletStore(
     (s) => s.status === "connecting" || s.status === "checking"
   );
+  const resolvedRound = useRoundStore((state) => state.resolvedRound);
+  const dismissResolvedRound = useRoundStore((state) => state.dismissResolvedRound);
   const [isBetModalOpen, setIsBetModalOpen] = useState(false);
   const [pendingPrediction, setPendingPrediction] = useState<PredictionData | null>(null);
   const timeoutRef = useRef<number | null>(null);
@@ -38,6 +43,40 @@ const Dashboard = () => {
     setPendingPrediction(data);
     setIsBetModalOpen(true);
   };
+
+  const getEndRoundResult = (round: Round | null) => {
+    const defaultTip = 'Stay tuned for the next round.';
+
+    if (!round) {
+      return {
+        isWin: false,
+        amount: 0,
+        tip: defaultTip,
+      };
+    }
+
+    const isWin = typeof round.isWin === 'boolean'
+      ? round.isWin
+      : String(round.outcome ?? round.result ?? '').toLowerCase() === 'win';
+
+    const amount = typeof round.netChange === 'number'
+      ? round.netChange
+      : typeof round.profit === 'number'
+      ? round.profit
+      : typeof round.score === 'number'
+      ? round.score
+      : 0;
+
+    const tip = typeof round.tip === 'string'
+      ? round.tip
+      : typeof round.note === 'string'
+      ? round.note
+      : defaultTip;
+
+    return { isWin, amount, tip };
+  };
+
+  const endRoundResult = getEndRoundResult(resolvedRound);
 
   return (
     <div className="xelma-grid-bg min-h-screen px-4 py-8 sm:px-6 lg:px-8">
@@ -80,6 +119,11 @@ const Dashboard = () => {
         onSuccess={(txHash: string) => {
           console.log("Prediction confirmed on-chain. TxHash:", txHash);
         }}
+      />
+      <EndRoundModal
+        isOpen={Boolean(resolvedRound)}
+        onClose={dismissResolvedRound}
+        result={endRoundResult}
       />
     </div>
   );

--- a/src/pages/Pools.tsx
+++ b/src/pages/Pools.tsx
@@ -1,0 +1,191 @@
+import { useState, useEffect } from 'react';
+
+// Typed mock data
+type PoolAsset = 'BTC' | 'ETH' | 'XLM';
+
+interface PoolStats {
+  asset: PoolAsset;
+  totalVolume: number;
+  upDownPool: {
+    total: number;
+    up: number;
+    down: number;
+  };
+  precisionPool: {
+    total: number;
+    predictions: number;
+  };
+  historicalYield: number;
+}
+
+const mockPoolData: PoolStats[] = [
+  {
+    asset: 'BTC',
+    totalVolume: 1250000,
+    upDownPool: { total: 850000, up: 450000, down: 400000 },
+    precisionPool: { total: 400000, predictions: 124 },
+    historicalYield: 4.2,
+  },
+  {
+    asset: 'ETH',
+    totalVolume: 820000,
+    upDownPool: { total: 600000, up: 350000, down: 250000 },
+    precisionPool: { total: 220000, predictions: 89 },
+    historicalYield: 3.8,
+  },
+  {
+    asset: 'XLM',
+    totalVolume: 450000,
+    upDownPool: { total: 300000, up: 100000, down: 200000 },
+    precisionPool: { total: 150000, predictions: 45 },
+    historicalYield: 5.1,
+  },
+];
+
+const ASSET_ICONS: Record<string, string> = {
+  BTC: '₿',
+  ETH: 'Ξ',
+  XLM: '✦',
+};
+
+export default function Pools() {
+  const [data, setData] = useState<PoolStats[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error] = useState<string | null>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      // Simulate successful fetch
+      setData(mockPoolData);
+      setLoading(false);
+    }, 800);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-[#2C4BFD] border-t-transparent"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center px-4">
+        <div className="glass-card rounded-2xl p-8 text-center text-rose-400">
+          <p className="text-lg font-bold">{error}</p>
+          <button
+            type="button"
+            className="mt-4 rounded-lg bg-white/5 px-4 py-2 text-sm hover:bg-white/10 transition-colors"
+            onClick={() => window.location.reload()}
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center px-4">
+        <div className="glass-card rounded-2xl p-8 text-center text-gray-400">
+          <p className="text-lg">No active pools found.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8 animate-in fade-in duration-500">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold tracking-tight text-white">Liquidity Pools</h1>
+        <p className="mt-2 text-gray-400">
+          Transparency and historical stats for all active round pools.
+        </p>
+      </header>
+
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {data.map((pool) => (
+          <PoolCard key={pool.asset} pool={pool} />
+        ))}
+      </div>
+    </main>
+  );
+}
+
+function PoolCard({ pool }: { pool: PoolStats }) {
+  const upPct =
+    pool.upDownPool.total > 0
+      ? Math.round((pool.upDownPool.up / pool.upDownPool.total) * 100)
+      : 0;
+  const downPct = pool.upDownPool.total > 0 ? 100 - upPct : 0;
+
+  return (
+    <article className="glass-card rounded-2xl p-6 transition-all duration-300">
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#2C4BFD]/15 text-lg font-bold text-[#BEC7FE]">
+            {ASSET_ICONS[pool.asset] || '?'}
+          </span>
+          <h2 className="text-xl font-bold text-white">{pool.asset} Pool</h2>
+        </div>
+      </div>
+
+      <div className="mb-6">
+        <p className="text-sm font-medium text-gray-400">Total Volume</p>
+        <p className="text-2xl font-bold text-white">
+          {pool.totalVolume.toLocaleString()} <span className="text-sm font-normal text-gray-500">vXLM</span>
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        {/* UP/DOWN Pool */}
+        <div className="rounded-xl bg-white/5 p-4">
+          <h3 className="mb-2 text-sm font-semibold text-gray-300">UP/DOWN Pool</h3>
+          <p className="mb-2 text-lg font-bold text-[#BEC7FE]">
+            {pool.upDownPool.total.toLocaleString()} <span className="text-xs font-normal text-gray-500">vXLM</span>
+          </p>
+          <div className="flex h-2 overflow-hidden rounded-full bg-gray-800">
+            <div
+              className="bg-[#2C4BFD] transition-all"
+              style={{ width: `${upPct}%` }}
+              title={`UP ${upPct}%`}
+            />
+            <div
+              className="bg-rose-500 transition-all"
+              style={{ width: `${downPct}%` }}
+              title={`DOWN ${downPct}%`}
+            />
+          </div>
+          <div className="mt-1 flex justify-between text-xs font-medium">
+            <span className="text-[#BEC7FE]">UP {upPct}%</span>
+            <span className="text-rose-400">DOWN {downPct}%</span>
+          </div>
+        </div>
+
+        {/* Precision Pool */}
+        <div className="rounded-xl bg-white/5 p-4">
+          <h3 className="mb-2 text-sm font-semibold text-gray-300">Precision Pool</h3>
+          <div className="flex items-end justify-between">
+            <p className="text-lg font-bold text-cyan-300">
+              {pool.precisionPool.total.toLocaleString()} <span className="text-xs font-normal text-gray-500">vXLM</span>
+            </p>
+            <p className="text-xs text-gray-400">{pool.precisionPool.predictions} predictions</p>
+          </div>
+        </div>
+
+        {/* Historical Stats */}
+        <div className="rounded-xl border border-white/5 bg-transparent p-4">
+          <h3 className="mb-1 text-xs font-semibold uppercase tracking-wider text-gray-500">
+            Historical Yield
+          </h3>
+          <p className="text-lg font-bold text-emerald-400">
+            +{pool.historicalYield}% <span className="text-xs font-normal text-gray-500">avg/round</span>
+          </p>
+        </div>
+      </div>
+    </article>
+  );
+}


### PR DESCRIPTION
closes #128

This PR implements the initial "Pools" page shell for liquidity and round pool transparency, addressing issue #128. It connects the new page via the main navigation and uses purely typed mock data internally, allowing for an easy swap to live API data once it's available.

