### PR TITLE
feat: Create reusable emptystate component for lists and panels

### DIFF
--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -303,6 +303,14 @@ export function ChatSidebar({ showNewsRibbon = true }: ChatSidebarProps) {
           ref={messagesContainerRef}
           className="flex-1 overflow-y-auto px-2.5 flex flex-col gap-3 bg-[#FAFAFA] dark:bg-gray-900 mx-2.5 p-3.5 rounded-xl overscroll-contain"
         >
+          {messages.length === 0 && (
+            <EmptyState
+              icon={<MessageCircle className="h-10 w-10 text-[#2C4BFD] dark:text-xelma-blue" />}
+              title="No messages yet"
+              description="Be the first to say something in the chat."
+              className="min-h-[160px] border-none bg-transparent backdrop-blur-none"
+            />
+          )}
           {messages.map((message) => (
             <div
               key={message.id}

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { Inbox } from 'lucide-react';
+import { cn } from '../lib/utils';
+
+export interface EmptyStateAction {
+  /** Button label */
+  label: string;
+  /** Click handler */
+  onClick: () => void;
+  /** Optional additional class names for the button */
+  className?: string;
+}
+
+export interface EmptyStateProps {
+  /**
+   * The primary headline — be specific about what's missing.
+   * e.g. "No notifications yet" not "Nothing here"
+   */
+  title: string;
+
+  /**
+   * A single sentence that tells the user what to do next.
+   * e.g. "Predictions you make will appear here once a round starts."
+   */
+  description: string;
+
+  /**
+   * Optional icon rendered above the title.
+   * Defaults to a generic inbox icon when omitted.
+   * Pass a Lucide icon or any React node sized to your context:
+   *   <Trophy className="h-12 w-12 text-xelma-teal" />
+   */
+  icon?: React.ReactNode;
+
+  /**
+   * Optional call-to-action rendered below the description.
+   * Use sparingly — only when there's a clear next step the user can take
+   * directly from this empty state.
+   */
+  action?: EmptyStateAction;
+
+  /** Additional Tailwind classes to override outer container sizing/spacing. */
+  className?: string;
+}
+
+/**
+ * EmptyState
+ *
+ * A shared presentational component for zero-content panels across Xelma:
+ * notifications, leaderboard, chat, prediction history, and future terminal panels.
+ *
+ * Design tokens used:
+ *   - Background:  bg-[#111827]/40  (--color-xelma-card with alpha)
+ *   - Border:      border-white/10   (dashed, subtle glass edge)
+ *   - Title:       text-white
+ *   - Description: text-gray-400
+ *   - Action:      bg-xelma-blue / hover:bg-xelma-blue-dark  (--color-xelma-blue)
+ *
+ * Dark mode is handled automatically — this component targets Xelma's
+ * dark-first design system (bg-[#0a0f1a] base) but also carries
+ * `dark:` variants so it degrades gracefully in any light-mode panel
+ * (e.g. the NotificationsPanel which uses bg-white in light mode).
+ *
+ * @example — Notifications panel (no icon override needed)
+ * ```tsx
+ * <EmptyState
+ *   title="No notifications"
+ *   description="You're all caught up. New activity will appear here."
+ * />
+ * ```
+ *
+ * @example — Leaderboard panel with a custom icon
+ * ```tsx
+ * import { Trophy } from 'lucide-react';
+ *
+ * <EmptyState
+ *   icon={<Trophy className="h-12 w-12 text-xelma-teal mb-4" />}
+ *   title="No leaderboard data yet"
+ *   description="Be the first to make a prediction and claim the top spot."
+ *   action={{ label: 'Start predicting', onClick: () => navigate('/game') }}
+ * />
+ * ```
+ *
+ * @example — Chat sidebar (empty message history)
+ * ```tsx
+ * import { MessageCircle } from 'lucide-react';
+ *
+ * <EmptyState
+ *   icon={<MessageCircle className="h-10 w-10 text-xelma-blue mb-3" />}
+ *   title="No messages yet"
+ *   description="Be the first to say something."
+ *   className="min-h-[160px]"
+ * />
+ * ```
+ */
+export const EmptyState: React.FC<EmptyStateProps> = ({
+  title,
+  description,
+  icon,
+  action,
+  className,
+}) => {
+  return (
+    <div
+      className={cn(
+        // Layout
+        'flex flex-col items-center justify-center p-10 text-center rounded-2xl min-h-[200px]',
+        // Dark-first glass surface — matches Xelma's panel aesthetic
+        'border border-dashed border-white/10 bg-[#111827]/40 backdrop-blur-sm',
+        // Light-mode fallback (e.g. NotificationsPanel white panel)
+        'dark:bg-[#111827]/40 dark:border-white/10',
+        'bg-gray-50/60 border-gray-200/60',
+        className,
+      )}
+      // Assistive: treat as a status region so screen readers announce it
+      role="status"
+      aria-live="polite"
+    >
+      {/* Icon */}
+      <span aria-hidden="true" className="mb-4 flex items-center justify-center">
+        {icon ?? (
+          <Inbox className="h-12 w-12 text-gray-400 dark:text-gray-500" />
+        )}
+      </span>
+
+      {/* Title */}
+      <h3 className="text-lg font-bold text-gray-900 dark:text-white mb-1.5">
+        {title}
+      </h3>
+
+      {/* Description */}
+      <p className="text-sm text-gray-500 dark:text-gray-400 max-w-xs leading-relaxed">
+        {description}
+      </p>
+
+      {/* Optional action */}
+      {action && (
+        <button
+          type="button"
+          onClick={action.onClick}
+          className={cn(
+            'mt-6 inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold',
+            'bg-xelma-blue hover:bg-xelma-blue-dark text-white',
+            'transition-all duration-150 hover:scale-[1.02] active:scale-[0.98]',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-xelma-blue focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0F1A]',
+            action.className,
+          )}
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default EmptyState;

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -3,7 +3,8 @@ import clsx from 'clsx';
 import Avatar from '../assets/avatar.svg';
 import { leaderboardApi, type LeaderboardEntry } from '../lib/api-client';
 import { useWalletStore, selectIsWalletConnected } from '../store/useWalletStore';
-import { LoadingState, ErrorState, EmptyState } from './ui/StatusStates';
+import { LoadingState, ErrorState } from './ui/StatusStates';
+import { EmptyState } from './EmptyState';
 
 interface LeaderboardUser {
   id: string;
@@ -272,7 +273,7 @@ const Leaderboard = () => {
         ) : sortedUsers.length === 0 ? (
           <EmptyState
             title="No leaderboard data yet"
-            message="Be the first to make a prediction and climb to the top!"
+            description="Be the first to make a prediction and claim the top spot."
             className="max-w-xl mx-auto"
           />
         ) : null}

--- a/src/components/NotificationsPanel.tsx
+++ b/src/components/NotificationsPanel.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import { useNotificationsStore } from '../store/useNotificationsStore';
 import { Clock, Check } from './icons';
-import { LoadingState, ErrorState, EmptyState } from './ui/StatusStates';
+import { LoadingState, ErrorState } from './ui/StatusStates';
+import { EmptyState } from './EmptyState';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 
 const NotificationsPanel: React.FC<{ id: string; onClose: () => void }> = ({
@@ -77,10 +78,10 @@ const NotificationsPanel: React.FC<{ id: string; onClose: () => void }> = ({
         )}
         {!loadingList && !errorList && list.length === 0 && (
           <EmptyState
+            icon={<Clock className="h-12 w-12 text-gray-300 dark:text-gray-600" />}
             title="No notifications"
-            message="You're all caught up! New notifications will appear here."
-            icon={<Clock className="h-12 w-12 text-gray-300 dark:text-gray-700 mb-4" />}
-            className="p-4"
+            description="You're all caught up. New activity will show up here."
+            className="min-h-[200px]"
           />
         )}
         {!loadingList && !errorList && list.length > 0 && (
@@ -100,7 +101,7 @@ const NotificationsPanel: React.FC<{ id: string; onClose: () => void }> = ({
                 {!n.read && (
                   <button
                     type="button"
-                    aria-label={`Mark notification “${n.title}” as read`}
+                    aria-label={`Mark notification "${n.title}" as read`}
                     onClick={() => markAsRead(n.id)}
                     className="shrink-0 p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
                   >


### PR DESCRIPTION
## Summary

Implements a shared `EmptyState` component to replace the ad hoc empty-state patterns spread across notifications, leaderboard, and chat panels. Previously, each panel either rolled its own inline empty UI or had none at all (ChatSidebar showed a blank scroll area when no messages existed).

Closes #173

---

## Changes

### New
- `src/components/EmptyState.tsx` — shared presentational component with `icon`, `title`, `description`, and optional `action` props. Fully typed via `EmptyStateProps` and `EmptyStateAction` interfaces. Includes JSDoc with three usage examples.

### Updated
- `src/components/NotificationsPanel.tsx` — replaced inline `EmptyState` import from `ui/StatusStates` with the new shared component
- `src/components/ChatSidebar.tsx` — added missing empty state for when message history is empty (was a blank scroll area before)
- `src/components/Leaderboard.tsx` — updated import to use the new shared component

---

## Acceptance Criteria

- [x] New `src/components/EmptyState.tsx` created
- [x] Supports `icon`, `title`, `description`, and optional `action` props
- [x] Adopted in 3 existing panels (NotificationsPanel, ChatSidebar, Leaderboard)
- [x] Dark theme tokens used (`--color-xelma-card`, `--color-xelma-blue`, `dark:` variants)
- [x] Component documented via JSDoc with `@example` blocks

---

## Design Tokens

The component references Xelma's design system tokens defined in `index.css`:

| Token | Usage |
|---|---|
| `bg-[#111827]/40` | Glass card background (`--color-xelma-card` + alpha) |
| `border-white/10` | Dashed border, consistent with `.glass-card` |
| `bg-xelma-blue` | Action button fill (`--color-xelma-blue`) |
| `hover:bg-xelma-blue-dark` | Action button hover (`--color-xelma-blue-dark`) |

Light-mode panels (e.g. NotificationsPanel's white bg) are handled via `dark:` variant overrides on each token.

---

## Accessibility

- Container uses `role="status"` and `aria-live="polite"` so screen readers announce the empty state when it appears after a data fetch
- Icon node is wrapped in `aria-hidden="true"` to avoid redundant announcements
- Action button has full `focus-visible` ring support aligned with the rest of the UI