### PR TITLE
feat: Socket.IO URL normalizer and Soroban network badge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 VITE_API_BASE_URL=https://xelma-backend.onrender.com
 
+# Socket.IO / API base URL. Trailing /api is stripped automatically for socket connections.
+VITE_API_URL=http://localhost:3000
+
 # Stellar network to display in the app badge. Set to PUBLIC for mainnet.
 VITE_STELLAR_NETWORK=TESTNET

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,4 @@
 VITE_API_BASE_URL=https://xelma-backend.onrender.com
+
+# Stellar network to display in the app badge. Set to PUBLIC for mainnet.
+VITE_STELLAR_NETWORK=TESTNET

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -28,6 +28,24 @@ function truncateAddress(key: string): string {
   return `${key.slice(0, 4)}...${key.slice(-4)}`;
 }
 
+const NETWORK = (import.meta.env.VITE_STELLAR_NETWORK ?? 'TESTNET').toUpperCase();
+
+function NetworkBadge() {
+  const isMainnet = NETWORK === 'PUBLIC' || NETWORK === 'MAINNET';
+  return (
+    <span
+      className={`rounded-full border px-2.5 py-0.5 text-xs font-bold tracking-wide ${
+        isMainnet
+          ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-400'
+          : 'border-amber-500/40 bg-amber-500/10 text-amber-400'
+      }`}
+      aria-label={`Stellar network: ${NETWORK}`}
+    >
+      {isMainnet ? 'Mainnet' : 'Testnet'}
+    </span>
+  );
+}
+
 export default function Navbar() {
   const location = useLocation();
   const isConnected = useWalletStore(selectIsWalletConnected);
@@ -128,6 +146,7 @@ export default function Navbar() {
           {/* Desktop Wallet & Mobile Menu Toggle */}
           <div className="flex items-center gap-3">
             <div className="hidden items-center gap-3 md:flex">
+              <NetworkBadge />
               {isConnected && publicKey ? (
                 <>
                   <span className="rounded-lg border border-cyan-500/25 bg-cyan-500/10 px-3 py-1.5 text-xs font-semibold text-cyan-200">
@@ -191,6 +210,10 @@ export default function Navbar() {
               >
                 <X className="h-6 w-6" />
               </button>
+            </div>
+
+            <div className="mb-4">
+              <NetworkBadge />
             </div>
 
             <nav className="flex flex-col gap-4">

--- a/src/lib/__tests__/socket.test.ts
+++ b/src/lib/__tests__/socket.test.ts
@@ -24,7 +24,7 @@ vi.mock('../../store/useAuthStore', () => ({
 }));
 
 // Import after mocking
-import { socketService, type ConnectionState } from '../socket';
+import { socketService, normalizeSocketUrl, type ConnectionState } from '../socket';
 import { io } from 'socket.io-client';
 
 // Get the mocked socket instance
@@ -309,5 +309,31 @@ describe('Socket Service', () => {
       
       unsubscribe();
     });
+  });
+});
+
+describe('normalizeSocketUrl', () => {
+  it('strips /api suffix', () => {
+    expect(normalizeSocketUrl('http://localhost:3000/api')).toBe('http://localhost:3000');
+  });
+
+  it('strips /api/ with trailing slash', () => {
+    expect(normalizeSocketUrl('http://localhost:3000/api/')).toBe('http://localhost:3000');
+  });
+
+  it('leaves URL unchanged when no /api suffix', () => {
+    expect(normalizeSocketUrl('http://localhost:3000')).toBe('http://localhost:3000');
+  });
+
+  it('strips /api from a production URL', () => {
+    expect(normalizeSocketUrl('https://xelma-backend.onrender.com/api')).toBe('https://xelma-backend.onrender.com');
+  });
+
+  it('leaves production URL unchanged when no /api suffix', () => {
+    expect(normalizeSocketUrl('https://xelma-backend.onrender.com')).toBe('https://xelma-backend.onrender.com');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(normalizeSocketUrl('')).toBe('');
   });
 });

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -1,7 +1,12 @@
 import { io, Socket } from "socket.io-client";
 import { useAuthStore } from "../store/useAuthStore";
 
-const SOCKET_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
+/** Strips a trailing /api segment so Socket.IO connects to the server root, not the REST prefix. */
+export function normalizeSocketUrl(url: string): string {
+  return url.replace(/\/api\/?$/, '');
+}
+
+const SOCKET_URL = normalizeSocketUrl(import.meta.env.VITE_API_URL ?? "http://localhost:3000");
 
 // Connection status types
 export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';


### PR DESCRIPTION
## Summary

- **#149 Socket.IO URL normalizer:** Exported `normalizeSocketUrl(url)` strips a trailing `/api` or `/api/` segment from `VITE_API_URL` before passing it to `socket.io-client`, so both `http://localhost:3000` and `http://localhost:3000/api` style env values connect correctly. 6 new unit tests added to `src/lib/__tests__/socket.test.ts`. `VITE_API_URL` documented in `.env.example`.
- **#157 Soroban network badge:** `NetworkBadge` component reads `VITE_STELLAR_NETWORK` (defaults to `TESTNET`) and renders an amber pill for testnet or an emerald pill for mainnet (`PUBLIC`/`MAINNET`). Badge placed in the desktop nav bar (before wallet balance) and at the top of the mobile drawer. `VITE_STELLAR_NETWORK=TESTNET` documented in `.env.example`.

## Issues closed

Closes #149
Closes #157

## Test plan

- [ ] `VITE_API_URL=http://localhost:3000/api` — socket connects to `http://localhost:3000`
- [ ] `VITE_API_URL=http://localhost:3000` — socket connects unchanged
- [ ] All 6 new `normalizeSocketUrl` unit tests pass
- [ ] `VITE_STELLAR_NETWORK=TESTNET` shows amber "Testnet" badge in navbar on desktop and mobile
- [ ] `VITE_STELLAR_NETWORK=PUBLIC` shows emerald "Mainnet" badge
- [ ] Badge visible on all routed pages (sticky header)