### PR TITLE
#207 Hydrate ProfileSummaryCard from API on wallet connect

### DIFF
--- a/src/store/useProfileStore.test.ts
+++ b/src/store/useProfileStore.test.ts
@@ -10,6 +10,7 @@ const mockAuthStore = {
 vi.mock('./useAuthStore', () => ({
   useAuthStore: {
     getState: () => mockAuthStore,
+    subscribe: vi.fn(() => () => {}),
   },
 }));
 

--- a/src/store/useProfileStore.ts
+++ b/src/store/useProfileStore.ts
@@ -93,3 +93,12 @@ export const useProfileStore = create<ProfileState>((set) => ({
     }
   },
 }));
+
+useAuthStore.subscribe(
+  (state) => state.jwt,
+  (jwt, prevJwt) => {
+    if (jwt && jwt !== prevJwt) {
+      useProfileStore.getState().loadProfile();
+    }
+  },
+);


### PR DESCRIPTION
## Problem
ProfileSummaryCard on legacy dashboard may show stale/empty data until user opens settings modal.

## Changes
- Added subscription to `useAuthStore.jwt` in `useProfileStore` that auto-triggers `loadProfile()` when the JWT changes (wallet connects and auth succeeds)
- Fixed mock in `useProfileStore.test.ts` to include `subscribe` for the new module-level subscription

## Acceptance Criteria
- Display name/avatar populate after connect without manual refresh
- Skeleton shown while loading
- Graceful fallback when profile API unavailable

close #207 