### PR TITLE
feat: add skeleton loading states to Dashboard

### DIFF
--- a/src/components/DashboardSkeleton.tsx
+++ b/src/components/DashboardSkeleton.tsx
@@ -1,0 +1,97 @@
+import { cn } from "../lib/utils";
+
+interface SkeletonBlockProps extends React.HTMLAttributes<HTMLDivElement> {
+  className?: string;
+}
+
+function SkeletonBlock({ className, style, ...rest }: SkeletonBlockProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl bg-white/[0.03] motion-safe:animate-pulse",
+        className
+      )}
+      style={style}
+      aria-hidden="true"
+      {...rest}
+    />
+  );
+}
+
+export default function DashboardSkeleton() {
+  return (
+    <div
+      className="xelma-grid-bg min-h-screen px-4 py-8 sm:px-6 lg:px-8"
+      role="status"
+      aria-label="Loading dashboard"
+    >
+      <div className="mx-auto max-w-7xl">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {/* Prediction Card Skeleton (left sidebar) */}
+          <div className="lg:col-span-1 flex flex-col gap-6">
+            <div className="glass-card rounded-2xl p-5">
+              <SkeletonBlock className="h-7 w-3/4 mb-6 mx-auto" />
+              <SkeletonBlock className="h-6 w-1/2 mb-4 mx-auto" />
+
+              <div className="grid grid-cols-2 gap-4 mb-6">
+                <SkeletonBlock className="h-20 rounded-xl" />
+                <SkeletonBlock className="h-20 rounded-xl" />
+              </div>
+
+              <SkeletonBlock className="h-4 w-1/3 mb-3" />
+              <SkeletonBlock className="h-12 w-full mb-4 rounded-lg" />
+
+              <SkeletonBlock className="h-4 w-1/2 mb-3" />
+              <div className="flex items-center gap-3 mb-4">
+                <SkeletonBlock className="h-6 w-11 rounded-full" />
+                <SkeletonBlock className="h-4 w-24" />
+              </div>
+
+              <SkeletonBlock className="h-5 w-2/3 mb-4" />
+              <SkeletonBlock className="h-10 w-full rounded-lg" />
+            </div>
+          </div>
+
+          {/* Right Column: Price Chart + Activity Feed */}
+          <div className="lg:col-span-2 flex flex-col gap-6">
+            {/* Price Chart Skeleton */}
+            <div className="glass-card rounded-xl min-h-[350px] p-6 border border-gray-100 dark:border-gray-700">
+              <SkeletonBlock className="h-5 w-32 mb-4" />
+              <div className="flex items-end gap-1 h-[280px]">
+                {[18, 28, 22, 55, 38, 62, 45, 72, 35, 58, 48, 82, 52, 68, 42, 78, 55, 88, 38, 65, 48, 72, 58, 42].map((pct, i) => (
+                  <SkeletonBlock
+                    key={i}
+                    className="flex-1 rounded-sm"
+                    style={{ height: `${pct}%` }}
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* Activity Feed Skeleton */}
+            <div className="glass-card rounded-2xl p-5">
+              <SkeletonBlock className="h-6 w-40 mb-4" />
+              <div className="space-y-3">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="flex items-center justify-between rounded-xl border border-white/5 bg-white/[0.02] px-4 py-3"
+                  >
+                    <div className="flex-1 space-y-1.5">
+                      <SkeletonBlock className="h-4 w-20" />
+                      <SkeletonBlock className="h-3 w-12" />
+                    </div>
+                    <div className="text-right space-y-1.5">
+                      <SkeletonBlock className="h-4 w-16 ml-auto" />
+                      <SkeletonBlock className="h-3 w-20 ml-auto" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -10,10 +10,12 @@ import type { Round } from "../lib/api-client";
 import { useWalletStore, selectIsWalletConnected } from "../store/useWalletStore";
 import { Link } from "react-router-dom";
 import EmptyState from '../components/EmptyState';
+import DashboardSkeleton from '../components/DashboardSkeleton';
 
 
 const Dashboard = () => {
   const isRoundActive = useRoundStore((state) => state.isRoundActive);
+  const isLoading = useRoundStore((state) => state.isLoading);
   const isWalletConnected = useWalletStore(selectIsWalletConnected);
   const isWalletConnecting = useWalletStore(
     (s) => s.status === "connecting" || s.status === "checking"
@@ -85,7 +87,9 @@ const Dashboard = () => {
   return (
     <div className="xelma-grid-bg min-h-screen px-4 py-8 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-7xl">
-        {!isWalletConnected && (
+        {isLoading && <DashboardSkeleton />}
+
+        {!isLoading && !isWalletConnected && (
           <div className="mb-6 flex flex-col gap-3 rounded-xl border border-[#2C4BFD]/30 bg-[#2C4BFD]/10 p-4 text-sm text-[#BEC7FE] sm:flex-row sm:items-center sm:justify-between sm:gap-4 sm:px-5 sm:py-4">
             <p className="leading-relaxed" data-testid="dashboard-wallet-prompt">
               Connect your wallet to submit predictions.
@@ -100,9 +104,11 @@ const Dashboard = () => {
           </div>
         )}
 
-        { !isRoundActive ? (
+        {!isLoading && !isRoundActive && (
           <EmptyState onRefresh={() => { const { fetchActiveRound } = useRoundStore.getState(); void fetchActiveRound(); }} />
-        ) : (
+        )}
+
+        {!isLoading && isRoundActive && (
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             <div className="dashboard__center lg:col-span-1 flex flex-col gap-6">
               <PredictionCard


### PR DESCRIPTION
closes #158 
## Summary

Adds skeleton loading states to the Dashboard page so users see placeholder UI while initial round data is being fetched, instead of instantly rendering mock data or an empty state.

---

## Problem

`/dashboard` renders mock data instantly with no loading states, which will feel broken once live API wiring lands.

## Changes

### `src/components/DashboardSkeleton.tsx` (new)

Skeleton component mirroring the dashboard's terminal card layout:

| Section | Placeholder |
|---------|-------------|
| **Prediction card** (left sidebar) | Title bar, mode buttons (UP/DOWN), stake input, toggle switch, submit button — all as rounded pulse blocks |
| **Price chart** (right top) | 24 bars with staggered heights inside a `glass-card` container |
| **Activity feed** (right bottom) | 5 rows matching `RecentActivity` item layout — asset name, result badge, amount |

- Pulse animations use `motion-safe:animate-pulse` — **no animation when `prefers-reduced-motion: reduce`**
- Uses `role="status"` and `aria-label="Loading dashboard"` for screen readers

### `src/pages/Dashboard.tsx` (modified)

- Reads `isLoading` from `useRoundStore`
- Renders `<DashboardSkeleton />` when `isLoading === true`
- All content blocks (wallet banner, `EmptyState`, prediction grid) are guarded with `!isLoading` to prevent double-rendering
- Bet modal and EndRound modal remain unconditionally rendered (no flicker on state transitions)

## Before / After

| State | Before | After |
|-------|--------|-------|
| **Loading** | `EmptyState` or mock data renders instantly | DashboardSkeleton with pulse placeholders |
| **No active round** | `EmptyState` appears immediately | Skeleton shows while fetching, then `EmptyState` |
| **Round active** | Grid renders with live data | Skeleton shows while fetching, then live grid |

## Testing

✓ 27/29 test suites pass (2 pre-existing failures: EmptyState stub)
✓ 408/411 tests pass (3 pre-existing failures)
✓ 0 new lint errors
✓ 0 TypeScript errors in modified files
✓ motion-safe prefix ensures no animation with prefers-reduced-motion

## Files Changed

| File | Action |
|------|--------|
| `src/components/DashboardSkeleton.tsx` | Added — skeleton placeholders |
| `src/pages/Dashboard.tsx` | Modified — isLoading conditional rendering |