### PR TITLE
feat(api): surface 429 rate-limit feedback to users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,13 @@
         "@stellar/freighter-api": "^6.0.1",
         "@stellar/stellar-sdk": "^12.0.0",
         "@tailwindcss/vite": "^4.1.18",
+        "@tanstack/react-virtual": "^3.14.4",
         "clsx": "^2.1.1",
         "lightweight-charts": "^5.1.0",
         "lucide-react": "^0.563.0",
         "next-themes": "^0.4.6",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-hot-toast": "^2.6.0",
         "react-router-dom": "^7.12.0",
         "socket.io-client": "^4.8.3",
         "sonner": "^2.0.7",
@@ -2363,6 +2363,33 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.4.tgz",
+      "integrity": "sha512-dZzAQP2uCDAd+9sAehqmx/DcU+B91Q4Gb0aDSM7t9bJvWDyGF9sapFNW5r1gNLsHs4wTb6ScZENJeYaHxJLiOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.2.tgz",
+      "integrity": "sha512-w43MvWvmShpb6kIC9MOoLyUkLmRTLPjt61bHWs+X29hACSpX+n8DvgZ3qM7cUfflKlRRcHR9KVJE6TmcqnQvcA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -3591,6 +3618,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -4394,15 +4422,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/goober": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
-      "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -5685,23 +5704,6 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
-      }
-    },
-    "node_modules/react-hot-toast": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
-      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.1.3",
-        "goober": "^2.1.16"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const clearAuthMock = vi.fn();
+const notifyRateLimitedMock = vi.fn();
 
 vi.mock('../store/useAuthStore', () => ({
   useAuthStore: {
@@ -11,10 +12,15 @@ vi.mock('../store/useAuthStore', () => ({
   },
 }));
 
+vi.mock('./rate-limit-toast', () => ({
+  notifyRateLimited: notifyRateLimitedMock,
+}));
+
 describe('apiFetch', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     clearAuthMock.mockReset();
+    notifyRateLimitedMock.mockReset();
   });
 
   it('returns JSON on 200', async () => {
@@ -75,6 +81,46 @@ describe('apiFetch', () => {
       status: 500,
       message: 'Server error. Please try again shortly.',
     });
+  });
+
+  it('surfaces a rate-limit message and notifies the user on 429', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(null, {
+          status: 429,
+          headers: { 'Retry-After': '30' },
+        })
+      )
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).rejects.toMatchObject({
+      status: 429,
+      message: 'Too many requests. Please slow down and try again shortly.',
+      retryAfterSeconds: 30,
+    });
+    expect(notifyRateLimitedMock).toHaveBeenCalledTimes(1);
+    expect(notifyRateLimitedMock).toHaveBeenCalledWith(30);
+  });
+
+  it('passes null retry-after when the header is absent on 429', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(null, { status: 429 }))
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).rejects.toMatchObject({ status: 429 });
+    expect(notifyRateLimitedMock).toHaveBeenCalledWith(null);
+  });
+
+  it('does not notify the rate limiter for non-429 errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('Internal Error', { status: 500 }))
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).rejects.toMatchObject({ status: 500 });
+    expect(notifyRateLimitedMock).not.toHaveBeenCalled();
   });
 
   it('throws timeout code on aborted request', async () => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { useAuthStore } from '../store/useAuthStore';
+import { notifyRateLimited } from './rate-limit-toast';
 
 const API_BASE = import.meta.env.VITE_API_URL ?? '';
 const DEFAULT_TIMEOUT_MS = 15000;
@@ -15,6 +16,8 @@ export class ApiError extends Error {
   code?: string;
   details?: unknown;
   endpoint?: string;
+  /** Parsed `Retry-After` value (seconds) for 429 responses, when provided. */
+  retryAfterSeconds?: number | null;
 
   constructor(message: string, status: number, code?: string, details?: unknown, endpoint?: string) {
     super(message);
@@ -56,8 +59,32 @@ function defaultMessageForStatus(status: number, endpoint: string): string {
   if (status === 401) return 'Your session has expired. Please reconnect and try again.';
   if (status === 403) return 'You do not have permission to perform this action.';
   if (status === 404) return 'Requested resource was not found.';
+  if (status === 429) return 'Too many requests. Please slow down and try again shortly.';
   if (status >= 500) return 'Server error. Please try again shortly.';
   return `Request failed: ${endpoint}`;
+}
+
+/**
+ * Parse an HTTP `Retry-After` header into seconds.
+ *
+ * Supports both the delta-seconds form (`"120"`) and the HTTP-date form
+ * (`"Wed, 21 Oct 2015 07:28:00 GMT"`). Returns `null` when absent or unparseable.
+ */
+function parseRetryAfter(response: Response, now: number = Date.now()): number | null {
+  const header = response.headers.get('Retry-After');
+  if (!header) return null;
+
+  const seconds = Number(header);
+  if (Number.isFinite(seconds)) {
+    return Math.max(0, Math.round(seconds));
+  }
+
+  const dateMs = Date.parse(header);
+  if (!Number.isNaN(dateMs)) {
+    return Math.max(0, Math.round((dateMs - now) / 1000));
+  }
+
+  return null;
 }
 
 function createApiError(endpoint: string, status: number, payload: ErrorPayload | null): ApiError {
@@ -112,6 +139,10 @@ export async function apiFetch<T>(endpoint: string, options: ApiFetchOptions = {
     if (!response.ok) {
       const payload = await parseErrorPayload(response);
       const apiError = createApiError(endpoint, response.status, payload);
+      if (response.status === 429) {
+        apiError.retryAfterSeconds = parseRetryAfter(response);
+        notifyRateLimited(apiError.retryAfterSeconds);
+      }
       if (import.meta.env.DEV) {
         console.debug('[apiFetch:error]', {
           endpoint,

--- a/src/lib/rate-limit-toast.test.ts
+++ b/src/lib/rate-limit-toast.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast } from 'sonner';
+import { notifyRateLimited, __resetRateLimitToast } from './rate-limit-toast';
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+const errorToast = vi.mocked(toast.error);
+
+describe('notifyRateLimited', () => {
+  beforeEach(() => {
+    __resetRateLimitToast();
+    errorToast.mockReset();
+  });
+
+  it('shows a toast with retry-after guidance in seconds', () => {
+    const shown = notifyRateLimited(30, 1_000);
+
+    expect(shown).toBe(true);
+    expect(errorToast).toHaveBeenCalledTimes(1);
+    expect(errorToast).toHaveBeenCalledWith(
+      'Too many requests',
+      expect.objectContaining({
+        id: 'api-rate-limit',
+        description: 'Please wait 30 seconds before trying again.',
+      }),
+    );
+  });
+
+  it('rounds long retry windows up to minutes', () => {
+    notifyRateLimited(90, 1_000);
+
+    expect(errorToast).toHaveBeenCalledWith(
+      'Too many requests',
+      expect.objectContaining({ description: 'Please wait 2 minutes before trying again.' }),
+    );
+  });
+
+  it('falls back to generic guidance when retry-after is unknown', () => {
+    notifyRateLimited(null, 1_000);
+
+    expect(errorToast).toHaveBeenCalledWith(
+      'Too many requests',
+      expect.objectContaining({ description: 'Please slow down and try again in a moment.' }),
+    );
+  });
+
+  it('uses a singular unit for a one second window', () => {
+    notifyRateLimited(1, 1_000);
+
+    expect(errorToast).toHaveBeenCalledWith(
+      'Too many requests',
+      expect.objectContaining({ description: 'Please wait 1 second before trying again.' }),
+    );
+  });
+
+  it('suppresses bursts within the cooldown window', () => {
+    expect(notifyRateLimited(5, 1_000)).toBe(true);
+    expect(notifyRateLimited(5, 2_000)).toBe(false);
+    expect(notifyRateLimited(5, 5_000)).toBe(false);
+
+    expect(errorToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows again once the cooldown has elapsed', () => {
+    expect(notifyRateLimited(5, 1_000)).toBe(true);
+    expect(notifyRateLimited(5, 6_001)).toBe(true);
+
+    expect(errorToast).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/rate-limit-toast.ts
+++ b/src/lib/rate-limit-toast.ts
@@ -1,0 +1,57 @@
+import { toast } from 'sonner';
+
+/** Stable id so concurrent 429s update a single toast instead of stacking. */
+const RATE_LIMIT_TOAST_ID = 'api-rate-limit';
+
+/**
+ * Minimum gap between rate-limit toasts. A burst of 429s firing within this
+ * window only surfaces a single toast so we never spam the user.
+ */
+const RATE_LIMIT_TOAST_COOLDOWN_MS = 5_000;
+
+let lastShownAt = Number.NEGATIVE_INFINITY;
+
+function formatRetryAfter(seconds: number): string {
+  if (seconds >= 60) {
+    const minutes = Math.ceil(seconds / 60);
+    return `${minutes} minute${minutes === 1 ? '' : 's'}`;
+  }
+  return `${seconds} second${seconds === 1 ? '' : 's'}`;
+}
+
+/**
+ * Surface a user-facing toast when the backend rate-limits a request (HTTP 429).
+ *
+ * Repeated calls within {@link RATE_LIMIT_TOAST_COOLDOWN_MS} are suppressed to
+ * avoid flooding the user during a burst of throttled requests.
+ *
+ * @param retryAfterSeconds Parsed `Retry-After` value, or `null` when unknown.
+ * @param now Injectable clock for deterministic tests.
+ * @returns `true` when a toast was shown, `false` when suppressed by the cooldown.
+ */
+export function notifyRateLimited(
+  retryAfterSeconds: number | null = null,
+  now: number = Date.now(),
+): boolean {
+  if (now - lastShownAt < RATE_LIMIT_TOAST_COOLDOWN_MS) {
+    return false;
+  }
+  lastShownAt = now;
+
+  const description =
+    retryAfterSeconds && retryAfterSeconds > 0
+      ? `Please wait ${formatRetryAfter(retryAfterSeconds)} before trying again.`
+      : 'Please slow down and try again in a moment.';
+
+  toast.error('Too many requests', {
+    id: RATE_LIMIT_TOAST_ID,
+    description,
+  });
+
+  return true;
+}
+
+/** Test-only helper to reset the dedupe window between cases. */
+export function __resetRateLimitToast(): void {
+  lastShownAt = Number.NEGATIVE_INFINITY;
+}


### PR DESCRIPTION
## Summary

Adds global, user-facing feedback when the backend rate-limits requests (HTTP 429). Previously a throttled request surfaced only a generic error (or nothing), leaving users unsure why an action failed or when to retry.

## Changes

- **Detect 429 in `apiFetch`** ([src/lib/api.ts](src/lib/api.ts)):
  - Parse the `Retry-After` header, supporting both the delta-seconds form (`"120"`) and the HTTP-date form.
  - Attach the parsed value to `ApiError.retryAfterSeconds` so callers can react programmatically.
  - Add a specific default message for 429 (`"Too many requests. Please slow down and try again shortly."`).
- **New `notifyRateLimited` helper** ([src/lib/rate-limit-toast.ts](src/lib/rate-limit-toast.ts)):
  - Shows a Sonner toast with retry-after guidance (e.g. `"Please wait 30 seconds before trying again."`), falling back to generic guidance when the header is absent.
  - Uses a **stable toast id** and a **5s cooldown** so a burst of 429s never spams the user with stacked toasts.

## Tests

- `src/lib/rate-limit-toast.test.ts` — message formatting (seconds/minutes/singular), unknown retry-after fallback, burst suppression, and re-show after cooldown.
- `src/lib/api.test.ts` — 429 produces the specific message + `retryAfterSeconds`, notifies the rate limiter with the parsed value (and `null` when absent), and does not notify on non-429 errors.

All unit tests, lint, and `tsc --noEmit` pass.

## Acceptance criteria

- [x] 429 produces a specific user-facing message
- [x] Does not spam toasts on burst errors

closes #211