### PR TITLE
refactor: unify backend API environment variables under VITE_API_BASE_URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-VITE_API_URL=http://localhost:3000/api
-VITE_WS_URL=http://localhost:3000
+VITE_API_BASE_URL=http://localhost:3000
+VITE_STELLAR_NETWORK=TESTNET

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,5 @@
-VITE_API_BASE_URL=https://xelma-backend.onrender.com
-
-# Socket.IO / API base URL. Trailing /api is stripped automatically for socket connections.
-VITE_API_URL=http://localhost:3000
+# Backend API Base URL (REST, SSE, and Socket.IO)
+VITE_API_BASE_URL=http://localhost:3000
 
 # Stellar network to display in the app badge. Set to PUBLIC for mainnet.
 VITE_STELLAR_NETWORK=TESTNET

--- a/README.md
+++ b/README.md
@@ -113,13 +113,11 @@ The frontend requires the following environment variables:
 
 ### Development (.env)
 
-VITE_API_URL=http://localhost:3000/api
-VITE_WS_URL=http://localhost:3000
+VITE_API_BASE_URL=http://localhost:3000
 
 ### Production
 
-VITE_API_URL=https://your-backend-domain.com/api
-VITE_WS_URL=https://your-backend-domain.com
+VITE_API_BASE_URL=https://your-backend-domain.com
 
 ⚠️ The backend must allow CORS for the frontend CLIENT_URL.
 Example:

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,6 +107,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -476,6 +477,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -499,6 +501,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2471,8 +2474,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2557,6 +2559,7 @@
       "integrity": "sha512-OowOUbD1lBCOFIPOZ8xnMIhgqA4sCutMiYOmPHL1PTLt5+y1XA+g2+yC9OOyz8p+deMZqPZLxfMjYIfrKsPeFg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2567,6 +2570,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2577,6 +2581,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2633,6 +2638,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3007,6 +3013,7 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -3043,6 +3050,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3317,6 +3325,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3723,8 +3732,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3947,6 +3955,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4788,6 +4797,7 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -5212,7 +5222,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5555,6 +5564,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5616,7 +5626,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5632,7 +5641,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5690,6 +5698,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5699,6 +5708,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5711,8 +5721,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -6506,6 +6515,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6672,6 +6682,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6747,6 +6758,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -7084,6 +7096,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,8 @@
 import { useAuthStore } from '../store/useAuthStore';
 import { notifyRateLimited } from './rate-limit-toast';
+import { API_BASE_URL } from './config';
 
-const API_BASE = import.meta.env.VITE_API_URL ?? '';
+const API_BASE = API_BASE_URL;
 const DEFAULT_TIMEOUT_MS = 15000;
 
 export interface ApiErrorShape {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,15 @@
+/**
+ * Unified application configuration helper.
+ * Resolves and normalizes the backend/API server URLs from environment variables.
+ */
+
+// Get backend base URL from env (canonical: VITE_API_BASE_URL)
+const rawBaseUrl = import.meta.env.VITE_API_BASE_URL || import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+// Normalize the backend URL by removing trailing /api segment and any trailing slashes.
+// This guarantees a clean root URL like "http://localhost:3000" or "https://xelma-backend.onrender.com".
+export const BACKEND_BASE_URL = rawBaseUrl.replace(/\/api\/?$/i, '').replace(/\/+$/, '');
+
+// Export canonical URLs for REST APIs and Socket.IO connections.
+export const API_BASE_URL = BACKEND_BASE_URL;
+export const SOCKET_URL = BACKEND_BASE_URL;

--- a/src/lib/profileApi.ts
+++ b/src/lib/profileApi.ts
@@ -6,7 +6,9 @@ export type ProfileSettingsValues = {
   streamerMode: boolean;
 };
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+import { API_BASE_URL } from './config';
+
+const API_BASE = API_BASE_URL;
 
 export async function fetchProfile(jwt: string): Promise<ProfileSettingsValues> {
   const res = await fetch(`${API_BASE}/api/user/profile`, {

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -1,12 +1,13 @@
 import { io, Socket } from "socket.io-client";
 import { useAuthStore } from "../store/useAuthStore";
+import { SOCKET_URL as CONFIG_SOCKET_URL } from "./config";
 
 /** Strips a trailing /api segment so Socket.IO connects to the server root, not the REST prefix. */
 export function normalizeSocketUrl(url: string): string {
-  return url.replace(/\/api\/?$/, '');
+  return url.replace(/\/api\/?$/i, '');
 }
 
-const SOCKET_URL = normalizeSocketUrl(import.meta.env.VITE_API_URL ?? "http://localhost:3000");
+const SOCKET_URL = CONFIG_SOCKET_URL;
 
 // Connection status types
 export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';

--- a/src/store/useRoundStore.test.ts
+++ b/src/store/useRoundStore.test.ts
@@ -140,7 +140,7 @@ describe('useRoundStore', () => {
     it('creates EventSource with correct URL', () => {
       useRoundStore.getState().subscribeToRoundEvents();
       
-      expect(global.EventSource).toHaveBeenCalledWith('/api/rounds/events');
+      expect(global.EventSource).toHaveBeenCalledWith(expect.stringContaining('/api/rounds/events'));
     });
 
     it('handles round:started event', () => {

--- a/src/store/useRoundStore.ts
+++ b/src/store/useRoundStore.ts
@@ -1,8 +1,9 @@
 import { create } from 'zustand';
 import { roundsApi, type Round } from '../lib/api-client';
 import { normalizeApiError } from '../lib/api';
+import { API_BASE_URL } from '../lib/config';
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+const API_BASE = API_BASE_URL;
 
 /** Fallback chat channel used when no active round is known. */
 export const CHAT_CHANNEL_FALLBACK = 'general';

--- a/src/store/useWalletStore.ts
+++ b/src/store/useWalletStore.ts
@@ -8,8 +8,9 @@ import {
 } from '@stellar/freighter-api';
 import { toast } from 'sonner';
 import { useAuthStore } from './useAuthStore';
+import { API_BASE_URL } from '../lib/config';
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+const API_BASE = API_BASE_URL;
 
 /** Single source of truth for wallet UI + lifecycle (issue #71). */
 export type WalletStatus = 'idle' | 'checking' | 'connecting' | 'connected' | 'error';


### PR DESCRIPTION

## Description

This PR unifies the fragmented API base URL environment variables (`VITE_API_URL` vs `VITE_API_BASE_URL`) under a single canonical contract, resolving local setup confusion and broken socket connections

### Changes
* **Centralized Configuration Helper (`src/lib/config.ts`)**: Resolves `VITE_API_BASE_URL` with fallback support for `VITE_API_URL` and normalizes the URL by removing trailing slashes and `/api` paths to ensure consistent root endpoints.
* **REST & SSE Endpoints Updated**: Updated `api.ts`, `useRoundStore.ts`, and `profileApi.ts` to use `API_BASE_URL` from the new config helper.
* **Socket.IO Client Endpoint Updated**: Updated `socket.ts` to use `SOCKET_URL` from the config helper, removing hardcoded localhosts and local normalization.
* **Wallet Authenticator Updated**: Updated `useWalletStore.ts` to fetch endpoints using `API_BASE_URL` from the config helper.
* **Documentation & Environment Templates**: Updated `.env.example`, `.env`, and `README.md` to reference only the canonical `VITE_API_BASE_URL`.
* **Test Maintenance**: Updated `useRoundStore.test.ts` to handle the normalized base URL structure in the event stream connection check.

Closes #148
