### PR TITLE
Add precision prediction input mode to BetModal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,71 +1,60 @@
 # Contributing to Xelma Frontend
 
-Thanks for contributing to Xelma — a trustless, dual-mode prediction market on Stellar.
+Thanks for contributing to Xelma — a trustless, dual-mode prediction market on Stellar. This guide is the starting point for local setup, app architecture, and pull request expectations.
 
-This document captures the **single, adopted app-shell pattern** for the frontend, decided under [issue #188](https://github.com/TevaLabs/Xelma-Frontend/issues/188). Make sure new pages and components fit it before opening a PR.
-
----
-
-## App shell pattern (the only one)
-
-We follow the **dark-terminal shell** in `src/App.tsx`. Every routed page renders inside it. There is **no other shared layout component** — please do not introduce one without first opening an issue.
-
-### What's in the shell (top → bottom)
-
-1. **`<OfflineBanner />`** — fixed-top red banner shown only when the realtime socket drops.
-2. **`<Navbar />`** — sticky, dark (`bg-[#0A0F1A]/90 backdrop-blur-xl`) top bar with logo, primary nav links, wallet connect, mobile drawer.
-3. **`<Routes>`** (wrapped in `<LazyBoundary>` + `<Suspense>`) — the active page.
-4. **`<Footer />`** — global session footer with Stellar branding, GitHub/learn links, and a decorative network badge. Rendered for every route **except `/`** (Landing renders its own Footer inside its bespoke hero).
-5. **`<Toaster />`** — `sonner` toast portal at `top-center`, dark theme.
-
-Source of truth: see [`src/App.tsx`](./src/App.tsx).
-
-### Required page conventions
-
-- Pages must render **outside** the shell container using the dark utility classes that already exist:
-  - Use the `xelma-grid-bg min-h-screen` wrapper for the fintech grid background.
-  - Center content with `mx-auto max-w-{6xl|7xl}` and horizontal padding `px-4 sm:px-6 lg:px-8` (matches Navbar/Footer).
-  - Use the dark palette tokens defined in [`src/index.css`](./src/index.css) (`--color-xelma-bg`, `--color-xelma-blue`, `--color-xelma-teal`, etc). Tailwind arbitrary values like `bg-[#0A0F1A]`, `text-[#F3F4F6]`, `border-[#BEC7FE]/10` are also fine.
-- Pages render their own header/title — do **not** add another `<header>`. The only `<header>` in the document is the one inside `Navbar`.
-- Reuse shared widgets instead of reimplementing: `<Footer />`, `<OfflineBanner />`, `<RouteFallback />`, `<LazyBoundary />`, `<ConnectThroughWallet>` (`WalletConnect`), educational components, etc.
-
-### What is **not** part of the shell (do not re-add)
-
-These components existed at some point and were removed because they were never wired into the routed tree and caused architectural confusion. Pull requests that re-introduce them will be rejected:
-
-| Removed component | Why it's gone |
-| --- | --- |
-| `src/components/layout/GameShell.tsx` | Light-bg (`#FAFAFA`) + `lg:px-14` model that conflicted with the dark-terminal pages. |
-| `src/components/Header.tsx` | Duplicate of `Navbar.tsx` and tied to the unused `next-themes` provider. |
-| `src/components/HeroSection.tsx` | Duplicated the bespoke Landing hero in `src/pages/Landing.tsx`. |
-| `src/components/RouteProgressBar.tsx` | Fixed-top `z-50` clashed with `<OfflineBanner />` and provided no signal that `<LazyBoundary>` + per-page loading states don't already give. |
-| `src/components/ThemeProvider.tsx` + `src/contexts/ThemeContext.tsx` | Never mounted; only the two above depended on `next-themes`, which has now been removed from `package.json`, `pnpm-lock.yaml`, and `package-lock.json`. |
-
-If you genuinely need a page-level layout primitive (e.g. a centered auth card), put it in the page file itself — do not create a global "shell" component. The dark-terminal shell in `App.tsx` is the single source of truth.
-
----
-
-## Local development
+## Local setup
 
 ```bash
-pnpm install          # primary install — regenerates pnpm-lock.yaml
-npm install           # ALSO run this — CI uses `npm ci`, which reads package-lock.json
-pnpm dev              # run Vite dev server
-pnpm test:unit        # run vitest
+pnpm install          # primary package manager; updates pnpm-lock.yaml
+npm install           # keep package-lock.json in sync because CI uses npm ci
+pnpm dev              # start the Vite dev server
+pnpm test:unit        # run the Vitest unit suite
 pnpm lint             # run ESLint
-pnpm build            # tsc + vite build (CI equivalent)
+pnpm build            # run TypeScript build plus Vite production build
 ```
 
-> **Heads-up:** CI (`.github/workflows/ci.yml`) runs `npm ci`, which reads **`package-lock.json`**, not `pnpm-lock.yaml`. When you bump or remove a dependency, run **both** `pnpm install` and `npm install` so the two lockfiles stay in sync. A half-refreshed lockfile will break CI with a phantom-dependency error.
+> CI runs `npm ci`, then the project checks from `package-lock.json`. If you change dependencies, refresh both `pnpm-lock.yaml` and `package-lock.json` before opening a PR.
 
-## Pull requests
+## Environment variables
 
-- Reference the issue you are closing (e.g. `Closes #188`).
-- Keep changes scoped — one concern per PR.
-- Run `npm run lint && npm run build && npm run test:unit` locally before pushing (this is what CI runs).
-- Confirm that no dead imports are left behind (the project enforces this; see the table above).
-- Prefer the existing dark-terminal styles; do not introduce new theme files without discussion.
+Create a local `.env` file when you need non-default services. Vite only exposes variables prefixed with `VITE_`.
 
-## Questions?
+| Variable | Required? | Default / notes |
+| --- | --- | --- |
+| `VITE_API_BASE_URL` | Required for integrated backend testing | Backend/API origin. Falls back to `VITE_API_URL`, then `http://localhost:3000`. |
+| `VITE_API_URL` | Optional legacy alias | Used only when `VITE_API_BASE_URL` is not set. |
+| `VITE_STELLAR_RPC_URL` | Optional for testnet defaults | Defaults to `https://soroban-testnet.stellar.org`. |
+| `VITE_XELMA_CONTRACT_ID` | Optional for current testnet contract | Defaults to the checked-in testnet contract id in `src/lib/xelma-contract.ts`. |
+| `VITE_STELLAR_NETWORK` | Optional display/config hint | Defaults to `TESTNET` where consumed. |
+| `VITE_STELLAR_NETWORK_PASSPHRASE` | Optional for testnet defaults | Defaults to Stellar Test SDF Network passphrase. |
 
-Open a GitHub discussion or mention `@maintainers` in your PR — happy to help shape changes that fit the architecture.
+Do not commit private keys, wallet secrets, production tokens, or personal RPC credentials.
+
+## Frontend architecture
+
+The app has a dual-dashboard model plus a standalone landing page:
+
+- `/` renders the bespoke public landing experience.
+- `/dashboard` renders the current terminal dashboard used for the primary connected prediction flow.
+- `/play` renders the legacy play dashboard kept available while terminal-dashboard work continues.
+
+All routed pages are composed under the dark terminal shell in `src/App.tsx`: `<OfflineBanner />`, `<Navbar />`, lazy routes, `<Footer />` (except the landing route), and `<Toaster />`. Avoid adding a second global shell or duplicate header. Prefer existing dark palette utilities and shared components.
+
+## Before opening a PR
+
+- [ ] Link the GitHub issue the PR addresses. Use `Closes #123` when appropriate.
+- [ ] Keep the PR focused on one concern.
+- [ ] Run `pnpm lint` and fix reported issues.
+- [ ] Run `pnpm test:unit` for unit coverage.
+- [ ] Run `pnpm build` for the TypeScript/Vite production build.
+- [ ] Include screenshots or a short screen recording for visible UI changes.
+- [ ] Mention any env vars, migrations, or manual QA steps reviewers need.
+
+## Finding work
+
+Start with the repository issue tracker:
+
+- [Open frontend issues](https://github.com/TevaLabs/Xelma-Frontend/issues?q=is%3Aissue+is%3Aopen)
+- [Open enhancement issues](https://github.com/TevaLabs/Xelma-Frontend/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
+
+If an issue is stale or underspecified, comment with your proposed approach before investing in a large change.

--- a/src/components/BetModal.tsx
+++ b/src/components/BetModal.tsx
@@ -19,6 +19,28 @@ interface BetModalProps {
 }
 
 type Step = 'confirm' | 'wallet_required' | 'preparing' | 'signing' | 'submitting' | 'syncing' | 'success' | 'error';
+type PredictionMode = 'direction' | 'precision';
+
+const PRICE_MIN = 0.0001;
+const PRICE_MAX = 10;
+const PRICE_DECIMALS = 4;
+
+function validateStake(value: string): string | null {
+  if (!value.trim()) return 'Enter a stake amount';
+  const amount = Number(value);
+  if (!Number.isFinite(amount) || amount <= 0) return 'Stake must be greater than 0';
+  return null;
+}
+
+function validateExactPrice(value: string): string | null {
+  if (!value.trim()) return 'Enter an exact price target';
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return 'Exact price must be a valid number';
+  if (amount < PRICE_MIN || amount > PRICE_MAX) return `Exact price must be between ${PRICE_MIN} and ${PRICE_MAX}`;
+  const decimals = value.split('.')[1];
+  if (decimals && decimals.length > PRICE_DECIMALS) return `Use ${PRICE_DECIMALS} decimal places or fewer`;
+  return null;
+}
 
 export default function BetModal({ isOpen, onClose, predictionData, onSuccess }: BetModalProps) {
   const isConnected = useWalletStore(selectIsWalletConnected);
@@ -32,8 +54,22 @@ export default function BetModal({ isOpen, onClose, predictionData, onSuccess }:
   const [errorMsg, setErrorMsg] = useState('');
   const [txHash, setTxHash] = useState('');
   const [isConnecting, setIsConnecting] = useState(false);
+  const [mode, setMode] = useState<PredictionMode>(predictionData?.isLegend ? 'precision' : 'direction');
+  const [direction, setDirection] = useState<'UP' | 'DOWN'>(predictionData?.direction ?? 'UP');
+  const [stake, setStake] = useState(predictionData?.stake ?? '');
+  const [exactPrice, setExactPrice] = useState(predictionData?.exactPrice ?? '');
+  const [formError, setFormError] = useState('');
 
   const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
+  const [prevPredictionData, setPrevPredictionData] = useState(predictionData);
+  if (predictionData !== prevPredictionData && isOpen) {
+    setPrevPredictionData(predictionData);
+    setMode(predictionData?.isLegend ? 'precision' : 'direction');
+    setDirection(predictionData?.direction ?? 'UP');
+    setStake(predictionData?.stake ?? '');
+    setExactPrice(predictionData?.exactPrice ?? '');
+    setFormError('');
+  }
   if (isOpen !== prevIsOpen) {
     setPrevIsOpen(isOpen);
     if (isOpen) {
@@ -41,6 +77,12 @@ export default function BetModal({ isOpen, onClose, predictionData, onSuccess }:
       setStep(targetStep);
       setErrorMsg('');
       setTxHash('');
+      setPrevPredictionData(predictionData);
+      setMode(predictionData?.isLegend ? 'precision' : 'direction');
+      setDirection(predictionData?.direction ?? 'UP');
+      setStake(predictionData?.stake ?? '');
+      setExactPrice(predictionData?.exactPrice ?? '');
+      setFormError('');
     }
   }
 
@@ -64,6 +106,17 @@ export default function BetModal({ isOpen, onClose, predictionData, onSuccess }:
   };
 
   const handleConfirm = async () => {
+    const stakeError = validateStake(stake);
+    const exactPriceError = mode === 'precision' ? validateExactPrice(exactPrice) : null;
+
+    if (stakeError || exactPriceError) {
+      setFormError(stakeError || exactPriceError || 'Invalid prediction details');
+      return;
+    }
+
+    setFormError('');
+    setStep('preparing');
+
     if (!publicKey || !isConnected) {
       setStep('wallet_required');
       return;
@@ -75,19 +128,21 @@ export default function BetModal({ isOpen, onClose, predictionData, onSuccess }:
       };
 
       let result;
-      if (predictionData.isLegend && predictionData.exactPrice) {
+      const isPrecision = mode === 'precision';
+
+      if (isPrecision) {
         result = await place_precision_prediction(
           publicKey,
-          predictionData.direction,
-          predictionData.stake,
-          predictionData.exactPrice,
+          direction,
+          stake,
+          exactPrice,
           updateStatus
         );
       } else {
         result = await place_bet(
           publicKey,
-          predictionData.direction,
-          predictionData.stake,
+          direction,
+          stake,
           updateStatus
         );
       }
@@ -97,10 +152,10 @@ export default function BetModal({ isOpen, onClose, predictionData, onSuccess }:
 
       // Submit to backend
       await predictionsApi.submit({
-        direction: predictionData.direction,
-        stake: predictionData.stake,
-        isLegend: predictionData.isLegend,
-        exactPrice: predictionData.exactPrice,
+        direction,
+        stake,
+        isLegend: mode === 'precision',
+        exactPrice: mode === 'precision' ? exactPrice : undefined,
       });
 
       setStep('success');
@@ -164,29 +219,98 @@ export default function BetModal({ isOpen, onClose, predictionData, onSuccess }:
               </div>
             )}
 
-            <div className="space-y-3 bg-gray-850 p-4 rounded-xl border border-gray-800 mb-6">
+            <div className="mb-5 grid grid-cols-2 rounded-xl border border-gray-800 bg-gray-950/70 p-1" role="tablist" aria-label="Prediction input mode">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={mode === 'direction'}
+                onClick={() => { setMode('direction'); setFormError(''); }}
+                className={`rounded-lg py-2 text-sm font-semibold transition ${mode === 'direction' ? 'bg-[#2C4BFD] text-white' : 'text-gray-400 hover:text-white'}`}
+              >
+                Direction
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={mode === 'precision'}
+                onClick={() => { setMode('precision'); setFormError(''); }}
+                className={`rounded-lg py-2 text-sm font-semibold transition ${mode === 'precision' ? 'bg-[#2C4BFD] text-white' : 'text-gray-400 hover:text-white'}`}
+              >
+                Precision
+              </button>
+            </div>
+
+            <div className="space-y-4 bg-gray-850 p-4 rounded-xl border border-gray-800 mb-6">
               <div className="flex justify-between">
                 <span className="text-gray-400">Mode</span>
                 <span className="font-semibold">
-                  {predictionData.isLegend ? 'Legend Mode (Precision)' : 'UP/DOWN Match'}
+                  {mode === 'precision' ? 'Legend Mode (Precision)' : 'UP/DOWN Match'}
                 </span>
               </div>
-              <div className="flex justify-between">
-                <span className="text-gray-400">Direction</span>
-                <span className={`font-bold ${predictionData.direction === 'UP' ? 'text-green-400' : 'text-red-400'}`}>
-                  {predictionData.direction}
-                </span>
+
+              <div>
+                <span className="mb-2 block text-sm text-gray-400">Direction</span>
+                <div className="grid grid-cols-2 gap-2">
+                  {(['UP', 'DOWN'] as const).map((option) => (
+                    <button
+                      key={option}
+                      type="button"
+                      onClick={() => setDirection(option)}
+                      className={`rounded-lg border px-3 py-2 font-bold transition ${
+                        direction === option
+                          ? option === 'UP'
+                            ? 'border-green-400 bg-green-500/15 text-green-400'
+                            : 'border-red-400 bg-red-500/15 text-red-400'
+                          : 'border-gray-700 text-gray-400 hover:border-gray-500 hover:text-white'
+                      }`}
+                    >
+                      {option}
+                    </button>
+                  ))}
+                </div>
               </div>
-              {predictionData.isLegend && predictionData.exactPrice && (
-                <div className="flex justify-between">
-                  <span className="text-gray-400">Target Price</span>
-                  <span className="font-semibold text-yellow-400">${predictionData.exactPrice}</span>
+
+              {mode === 'precision' && (
+                <div>
+                  <label htmlFor="bet-modal-exact-price" className="mb-2 block text-sm text-gray-400">
+                    Exact Price Target
+                  </label>
+                  <input
+                    id="bet-modal-exact-price"
+                    type="number"
+                    inputMode="decimal"
+                    min={PRICE_MIN}
+                    max={PRICE_MAX}
+                    step="0.0001"
+                    value={exactPrice}
+                    onChange={(event) => { setExactPrice(event.target.value); setFormError(''); }}
+                    className="w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-white outline-none transition focus:border-yellow-400"
+                    placeholder="0.2295"
+                  />
+                  {exactPrice && <p className="mt-2 text-xs font-semibold text-yellow-400">${exactPrice}</p>}
                 </div>
               )}
-              <div className="flex justify-between border-t border-gray-800 pt-3">
-                <span className="text-gray-400">Stake</span>
-                <span className="font-bold text-cyan-400">{predictionData.stake} XLM</span>
+
+              <div className="border-t border-gray-800 pt-3">
+                <label htmlFor="bet-modal-stake" className="mb-2 block text-sm text-gray-400">Stake</label>
+                <div className="flex items-center gap-2">
+                  <input
+                    id="bet-modal-stake"
+                    type="number"
+                    inputMode="decimal"
+                    min="0"
+                    step="0.0000001"
+                    value={stake}
+                    onChange={(event) => { setStake(event.target.value); setFormError(''); }}
+                    className="w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-white outline-none transition focus:border-cyan-400"
+                    placeholder="15"
+                  />
+                  <span className="font-bold text-cyan-400">XLM</span>
+                </div>
+                {stake && <p className="mt-2 text-xs text-cyan-300">{stake} XLM</p>}
               </div>
+
+              {formError && <p className="text-sm font-semibold text-red-400" role="alert">{formError}</p>}
             </div>
 
             <button

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -150,7 +150,7 @@ export default function Navbar() {
               {isConnected && publicKey ? (
                 <>
                   <span className="rounded-lg border border-cyan-500/25 bg-cyan-500/10 px-3 py-1.5 text-xs font-semibold text-cyan-200">
-                    {balance ?? '…'}
+                    {balance ? `${balance} vXLM` : '… vXLM'}
                   </span>
                   <span className="rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 font-mono text-xs text-gray-300">
                     {truncateAddress(publicKey)}
@@ -252,7 +252,7 @@ export default function Navbar() {
                   <div className="flex items-center justify-between px-2">
                     <span className="text-sm text-gray-400">Balance</span>
                     <span className="text-sm font-semibold text-cyan-200">
-                      {balance ?? '…'}
+                      {balance ? `${balance} vXLM` : '… vXLM'}
                     </span>
                   </div>
                   <div className="flex items-center justify-between px-2">

--- a/src/components/__tests__/BetModal.test.tsx
+++ b/src/components/__tests__/BetModal.test.tsx
@@ -278,15 +278,54 @@ describe('BetModal Component', () => {
         <BetModal isOpen={true} onClose={vi.fn()} predictionData={{ ...defaultPrediction, direction: 'UP' as const }} />
       );
 
-      expect(screen.getByText('UP')).toBeInTheDocument();
-      expect(screen.queryByText('DOWN')).not.toBeInTheDocument();
+      expect(screen.getByText('UP')).toHaveClass('text-green-400');
+      expect(screen.getByText('DOWN')).not.toHaveClass('text-red-400');
 
       rerender(
         <BetModal isOpen={true} onClose={vi.fn()} predictionData={{ ...defaultPrediction, direction: 'DOWN' as const }} />
       );
 
-      expect(screen.getByText('DOWN')).toBeInTheDocument();
-      expect(screen.queryByText('UP')).not.toBeInTheDocument();
+      expect(screen.getByText('DOWN')).toHaveClass('text-red-400');
+      expect(screen.getByText('UP')).not.toHaveClass('text-green-400');
+    });
+  });
+
+
+  describe('precision mode inputs', () => {
+    it('lets users enter an exact price in precision mode before submitting', async () => {
+      vi.mocked(place_precision_prediction).mockResolvedValue({ txHash: 'tx_hash_precision', ledger: 123 });
+      vi.mocked(predictionsApi.submit).mockResolvedValue({ id: 2 } as any);
+
+      render(
+        <BetModal isOpen={true} onClose={vi.fn()} predictionData={defaultPrediction} />
+      );
+
+      fireEvent.click(screen.getByRole('tab', { name: 'Precision' }));
+      fireEvent.change(screen.getByLabelText('Exact Price Target'), { target: { value: '0.4321' } });
+      fireEvent.change(screen.getByLabelText('Stake'), { target: { value: '22.5' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      await waitFor(() => {
+        expect(place_precision_prediction).toHaveBeenCalledWith('GUSER123', 'UP', '22.5', '0.4321', expect.any(Function));
+        expect(predictionsApi.submit).toHaveBeenCalledWith({
+          direction: 'UP',
+          stake: '22.5',
+          isLegend: true,
+          exactPrice: '0.4321',
+        });
+      });
+    });
+
+    it('prevents empty precision submissions', () => {
+      render(
+        <BetModal isOpen={true} onClose={vi.fn()} predictionData={{ ...defaultPrediction, stake: '' }} />
+      );
+
+      fireEvent.click(screen.getByRole('tab', { name: 'Precision' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      expect(screen.getByRole('alert')).toHaveTextContent('Enter a stake amount');
+      expect(place_precision_prediction).not.toHaveBeenCalled();
     });
   });
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -106,8 +106,19 @@ const Dashboard = () => {
 
         {!isLoading && !isRoundActive && (
           <EmptyState
-            title="No active round"
-            description="Check back soon for the next prediction round."
+            title="No Active Rounds"
+            description="Learn how the game works or refresh to check for new rounds."
+            action={
+              <button
+                type="button"
+                className="btn-primary rounded-lg px-4 py-2 text-sm font-semibold"
+                onClick={() => {
+                  void useRoundStore.getState().fetchActiveRound();
+                }}
+              >
+                Refresh
+              </button>
+            }
           />
         )}
 


### PR DESCRIPTION
close #161 

Description
Add an actionable CONTRIBUTING.md at the repo root documenting pnpm/npm install, pnpm dev, pnpm test:unit, pnpm lint, pnpm build, required VITE_ env vars, the dual-dashboard routes (/, /dashboard, /play), and a PR checklist.
Extend src/components/BetModal.tsx with a direction/precision tabbed input mode, editable stake and exactPrice fields, client-side validation (validateStake, validateExactPrice), and wiring to call place_precision_prediction for precision submissions and place_bet for direction mode; backend payloads now include isLegend and exactPrice per mode.
Update src/components/__tests__/BetModal.test.tsx to cover precision-mode input, validation, and submission; add assertions for the new selectable direction UI.
Restore vXLM display in src/components/Navbar.tsx balance badges and add a refreshable empty state to src/pages/Dashboard.tsx so the dashboard empty view exposes a Refresh action that invokes fetchActiveRound().


Testing
Ran pnpm lint which completed successfully with existing warnings in src/hooks/useFocusTrap.ts and src/pages/Dashboard.tsx.
Built the app with pnpm build which completed without errors.
Ran unit tests with pnpm test:unit (targeted runs for BetModal and Navbar during development and the full suite); all unit tests passed in the final run (full suite ran and completed successfully).
