### PR TITLE
feat(api): handle JWT expiry and 401/403 with reconnect flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -477,7 +476,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -501,7 +499,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2474,7 +2471,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2559,7 +2557,6 @@
       "integrity": "sha512-OowOUbD1lBCOFIPOZ8xnMIhgqA4sCutMiYOmPHL1PTLt5+y1XA+g2+yC9OOyz8p+deMZqPZLxfMjYIfrKsPeFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2570,7 +2567,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2581,7 +2577,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2638,7 +2633,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3013,7 +3007,6 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -3050,7 +3043,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3325,7 +3317,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3732,7 +3723,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3955,7 +3947,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4797,7 +4788,6 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -5222,6 +5212,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5564,7 +5555,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5626,6 +5616,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5641,6 +5632,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5698,7 +5690,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5708,7 +5699,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5721,7 +5711,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -6515,7 +6506,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6682,7 +6672,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6758,7 +6747,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -7096,7 +7084,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const clearAuthMock = vi.fn();
+const resetWalletMock = vi.fn();
 const notifyRateLimitedMock = vi.fn();
+const toastErrorMock = vi.fn(() => 'toast-id');
 
 vi.mock('../store/useAuthStore', () => ({
   useAuthStore: {
@@ -9,6 +11,20 @@ vi.mock('../store/useAuthStore', () => ({
       jwt: 'test-jwt',
       clearAuth: clearAuthMock,
     }),
+  },
+}));
+
+vi.mock('../store/useWalletStore', () => ({
+  useWalletStore: {
+    getState: () => ({
+      reset: resetWalletMock,
+    }),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: toastErrorMock,
   },
 }));
 
@@ -20,7 +36,9 @@ describe('apiFetch', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     clearAuthMock.mockReset();
+    resetWalletMock.mockReset();
     notifyRateLimitedMock.mockReset();
+    toastErrorMock.mockReset();
   });
 
   it('returns JSON on 200', async () => {
@@ -56,7 +74,7 @@ describe('apiFetch', () => {
     });
   });
 
-  it('clears auth and throws on 401', async () => {
+  it('clears auth, resets wallet, shows toast and throws on 401', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(
@@ -69,6 +87,56 @@ describe('apiFetch', () => {
     const { apiFetch } = await import('./api');
     await expect(apiFetch('/api/test')).rejects.toMatchObject({ status: 401 });
     expect(clearAuthMock).toHaveBeenCalledTimes(1);
+    expect(resetWalletMock).toHaveBeenCalledTimes(1);
+    expect(toastErrorMock).toHaveBeenCalled();
+  });
+
+  it('clears auth, resets wallet, shows toast and throws on 403', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message: 'Forbidden' }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).rejects.toMatchObject({ status: 403 });
+    expect(clearAuthMock).toHaveBeenCalledTimes(1);
+    expect(resetWalletMock).toHaveBeenCalledTimes(1);
+    expect(toastErrorMock).toHaveBeenCalled();
+  });
+
+  it('does not retry on 401 — only one fetch call is made', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchFn);
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).rejects.toMatchObject({ status: 401 });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses stable toast id on 401 so concurrent requests do not stack toasts', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    const { apiFetch } = await import('./api');
+    await expect(apiFetch('/api/test')).rejects.toThrow();
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Session expired',
+      expect.objectContaining({ id: 'session-expired', duration: Infinity }),
+    );
   });
 
   it('uses actionable fallback message on 500', async () => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,6 @@
+import { toast } from 'sonner';
 import { useAuthStore } from '../store/useAuthStore';
+import { useWalletStore } from '../store/useWalletStore';
 import { notifyRateLimited } from './rate-limit-toast';
 import { API_BASE_URL } from './config';
 
@@ -108,6 +110,23 @@ export function normalizeApiError(error: unknown, fallbackMessage = 'Something w
   return new ApiError(fallbackMessage, 0, 'UNKNOWN', undefined);
 }
 
+/** Stable toast id so concurrent 401/403 responses update a single toast. */
+const SESSION_EXPIRED_TOAST_ID = 'session-expired';
+
+function notifySessionExpired(): void {
+  toast.error('Session expired', {
+    id: SESSION_EXPIRED_TOAST_ID,
+    description: 'Your session has expired. Please reconnect your wallet.',
+    action: {
+      label: 'Reconnect',
+      onClick: () => {
+        window.location.href = '/';
+      },
+    },
+    duration: Infinity,
+  });
+}
+
 export async function apiFetch<T>(endpoint: string, options: ApiFetchOptions = {}): Promise<T> {
   const { jwt, clearAuth } = useAuthStore.getState();
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -133,8 +152,10 @@ export async function apiFetch<T>(endpoint: string, options: ApiFetchOptions = {
       signal: requestOptions.signal ?? controller.signal,
     });
 
-    if (response.status === 401) {
+    if (response.status === 401 || response.status === 403) {
       clearAuth();
+      useWalletStore.getState().reset();
+      notifySessionExpired();
     }
 
     if (!response.ok) {

--- a/src/store/useWalletStore.ts
+++ b/src/store/useWalletStore.ts
@@ -36,6 +36,7 @@ interface WalletState {
   networkMismatch: boolean;
   connect: () => Promise<void>;
   disconnect: () => void;
+  reset: () => void;
   checkConnection: () => Promise<void>;
   clearError: () => void;
 }
@@ -68,6 +69,18 @@ export const useWalletStore = create<WalletState>((set, get) => ({
   networkMismatch: false,
 
   clearError: () => set({ errorMessage: null, errorCode: null }),
+
+  reset: () => {
+    set({
+      status: 'idle',
+      publicKey: null,
+      network: null,
+      balance: null,
+      errorMessage: null,
+      errorCode: null,
+      networkMismatch: false,
+    });
+  },
 
   disconnect: () => {
     set({


### PR DESCRIPTION
Close #196 

PR: Handle JWT expiry and 401/403 API responses with reconnect flow
Problem
useAuthStore persists the JWT, but there is no global handler when the token expires or the API returns 401/403. Users may see silent failures on protected endpoints with no indication that their session is invalid.
Changes
src/store/useWalletStore.ts
- Added reset() method — clears all wallet state to idle without showing a "Wallet disconnected" toast. Useful for involuntary session expiry where showing a success toast is misleading.
src/lib/api.ts
- Imports toast from sonner and useWalletStore.
- Added notifySessionExpired() helper:
- Shows a persistent error toast with stable ID session-expired (prevents stacking concurrent 401s).
- Includes a "Reconnect" action button that navigates to /.
- Uses duration: Infinity so the toast stays until dismissed.
- On 401 or 403: calls clearAuth(), useWalletStore.getState().reset(), and notifySessionExpired(), then throws ApiError — no retry is attempted.
src/lib/api.test.ts
- Added mocks for useWalletStore (reset) and sonner (toast.error).
- Updated existing 401 test to verify wallet reset + toast are triggered.
- Added new tests:
- 403 handling — clears auth, resets wallet, shows session-expired toast.
- No infinite retry — confirms only one fetch call is made on 401.
- Stable toast ID — verifies toast uses id: 'session-expired' with duration: Infinity.
Acceptance Criteria Met
- 401/403 from protected API triggers clearAuth() + wallet reset + user-visible reconnect CTA (toast with action button)
- Does not infinite-retry failed requests (single fetch call, throws immediately)
- Concurrent 401s collapse into a single toast via stable ID