### PR TITLE
feat: add reusable ComingSoonPage component for placeholder routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import LazyBoundary from './components/LazyBoundary';
 import ErrorBoundary from './components/ErrorBoundary';
 import { OfflineBanner } from './components/OfflineBanner';
 import Footer from './components/Footer';
+import ComingSoonPage from './pages/ComingSoonPage';
+import { Trophy } from 'lucide-react';
 
 const Dashboard = lazy(() => import(/* webpackChunkName: "dashboard" */ './pages/Dashboard'));
 const LegacyDashboard = lazy(() => import(/* webpackChunkName: "legacy-dashboard" */ './pages/LegacyDashboard'));
@@ -42,9 +44,11 @@ function App() {
               <Route
                 path="/tournament"
                 element={
-                  <div className="xelma-grid-bg px-4 py-20 text-center text-xl font-bold text-gray-500">
-                    Tournament — Coming Soon
-                  </div>
+                  <ComingSoonPage
+                    icon={Trophy}
+                    title="Tournament"
+                    description="Competitive tournament mode is being built. Check back soon to compete for top rankings and exclusive rewards."
+                  />
                 }
               />
               <Route path="/profile" element={<Profile />} />

--- a/src/pages/ComingSoonPage.tsx
+++ b/src/pages/ComingSoonPage.tsx
@@ -1,0 +1,35 @@
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, type LucideIcon } from 'lucide-react';
+
+interface ComingSoonPageProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+}
+
+export default function ComingSoonPage({ icon: Icon, title, description }: ComingSoonPageProps) {
+  const navigate = useNavigate();
+
+  return (
+    <main className="xelma-grid-bg flex min-h-screen items-center justify-center px-4">
+      <div className="glass-card mx-auto max-w-md rounded-2xl p-10 text-center">
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-[#2C4BFD]/15">
+          <Icon className="h-8 w-8 text-[#BEC7FE]" aria-hidden />
+        </div>
+
+        <h1 className="mb-3 text-2xl font-black text-white">{title}</h1>
+
+        <p className="mb-8 text-sm leading-6 text-gray-400">{description}</p>
+
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          className="inline-flex items-center gap-2 rounded-lg bg-white/5 px-5 py-3 text-sm font-bold text-gray-300 transition-colors hover:bg-white/10 hover:text-white"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+          Go back
+        </button>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Creates a reusable `ComingSoonPage` component to replace inline placeholder JSX, matching the fintech terminal visual style.

## Changes

- **New** `src/pages/ComingSoonPage.tsx` — accepts `icon` (LucideIcon), `title`, and `description` props, with a "Go back" CTA button (`navigate(-1)`)
- **Updated** `src/App.tsx` — replaces the inline placeholder on `/tournament` with `<ComingSoonPage>`

## Acceptance criteria

- [x] Shared component used by `/tournament` and ready for any future placeholder routes
- [x] Matches fintech terminal visual style (`xelma-grid-bg`, `glass-card`, dark theme)

Closes #170 