### PR TITLE
Feat: Fix mobile nav drawer focus management + reduce PriceChart rerenders

### DIFF
--- a/src/components/Navbar.test.tsx
+++ b/src/components/Navbar.test.tsx
@@ -182,5 +182,21 @@ describe('Navbar', () => {
       fireEvent.click(closeButton);
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
+
+    it('closes the drawer when Escape is pressed', () => {
+      renderNavbar();
+      fireEvent.click(screen.getByRole('button', { name: /open mobile menu/i }));
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('returns focus to the hamburger trigger after the drawer closes', () => {
+      renderNavbar();
+      const menuButton = screen.getByRole('button', { name: /open mobile menu/i });
+      fireEvent.click(menuButton);
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(menuButton).toHaveFocus();
+    });
   });
 });

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,6 +7,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { Menu, X } from 'lucide-react';
 import { useWalletStore, selectIsWalletConnected } from '../store/useWalletStore';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import Logo from '../assets/logo.svg';
 
 interface NavLinkItem {
@@ -58,21 +59,19 @@ export default function Navbar() {
 
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const drawerRef = useRef<HTMLDivElement>(null);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+
+  const closeMenu = useCallback(() => setIsMobileMenuOpen(false), []);
 
   useEffect(() => {
     void checkConnection();
   }, [checkConnection]);
 
-  // Handle escape key to close mobile menu
-  useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isMobileMenuOpen) {
-        setIsMobileMenuOpen(false);
-      }
-    };
-    document.addEventListener('keydown', handleEscape);
-    return () => document.removeEventListener('keydown', handleEscape);
-  }, [isMobileMenuOpen]);
+  useFocusTrap(drawerRef, {
+    active: isMobileMenuOpen,
+    onEscape: closeMenu,
+    restoreFocusRef: menuButtonRef,
+  });
 
   // Handle click outside to close mobile menu
   useEffect(() => {
@@ -96,8 +95,6 @@ export default function Navbar() {
       document.body.style.overflow = '';
     };
   }, [isMobileMenuOpen]);
-
-  const closeMenu = useCallback(() => setIsMobileMenuOpen(false), []);
 
   return (
     <>
@@ -170,6 +167,7 @@ export default function Navbar() {
 
             {/* Mobile Menu Button */}
             <button
+              ref={menuButtonRef}
               type="button"
               className="md:hidden rounded-lg p-2 text-gray-400 hover:bg-white/5 hover:text-white transition-colors"
               onClick={() => setIsMobileMenuOpen(true)}

--- a/src/components/PriceChart.helpers.test.ts
+++ b/src/components/PriceChart.helpers.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { mergePricePoints } from './PriceChart.helpers';
+import type { PricePoint } from '../lib/api-client';
+
+const p = (time: number, value: number): PricePoint => ({ time, value });
+
+describe('mergePricePoints', () => {
+  it('returns the existing reference when the incoming batch is empty', () => {
+    const existing = [p(1, 10)];
+    expect(mergePricePoints(existing, [])).toBe(existing);
+  });
+
+  it('returns the existing reference when every incoming point is a duplicate', () => {
+    const existing = [p(1, 10), p(2, 11)];
+    const result = mergePricePoints(existing, [p(2, 11)]);
+    expect(result).toBe(existing);
+  });
+
+  it('returns a new array when a new timestamp arrives', () => {
+    const existing = [p(1, 10)];
+    const result = mergePricePoints(existing, [p(2, 11)]);
+    expect(result).not.toBe(existing);
+    expect(result).toEqual([p(1, 10), p(2, 11)]);
+  });
+
+  it('returns a new array when an existing timestamp changes value', () => {
+    const existing = [p(1, 10)];
+    const result = mergePricePoints(existing, [p(1, 12)]);
+    expect(result).not.toBe(existing);
+    expect(result).toEqual([p(1, 12)]);
+  });
+
+  it('keeps points sorted and capped at the most recent 500', () => {
+    const existing = Array.from({ length: 500 }, (_, i) => p(i, i));
+    const result = mergePricePoints(existing, [p(500, 500)]);
+    expect(result).toHaveLength(500);
+    expect(result[0]).toEqual(p(1, 1));
+    expect(result[result.length - 1]).toEqual(p(500, 500));
+  });
+});

--- a/src/components/PriceChart.helpers.ts
+++ b/src/components/PriceChart.helpers.ts
@@ -1,0 +1,23 @@
+import type { PricePoint } from "../lib/api-client";
+
+export function mergePricePoints(existing: PricePoint[], incoming: PricePoint[]): PricePoint[] {
+  if (incoming.length === 0) return existing;
+
+  const merged = new Map<number, PricePoint>();
+  for (const point of existing) merged.set(point.time, point);
+
+  let changed = false;
+  for (const point of incoming) {
+    const current = merged.get(point.time);
+    if (!current || current.value !== point.value) {
+      merged.set(point.time, point);
+      changed = true;
+    }
+  }
+
+  if (!changed) return existing;
+
+  return Array.from(merged.values())
+    .sort((a, b) => a.time - b.time)
+    .slice(-500);
+}

--- a/src/components/PriceChart.tsx
+++ b/src/components/PriceChart.tsx
@@ -8,6 +8,7 @@ import {
   type UTCTimestamp,
 } from "lightweight-charts";
 import { priceApi, type PricePoint } from "../lib/api-client";
+import { mergePricePoints } from "./PriceChart.helpers";
 import { socketService } from "../lib/socket";
 import { LoadingState, ErrorState } from "./ui/StatusStates";
 import { useConnectionStatus } from "../hooks/useConnectionStatus";
@@ -54,18 +55,6 @@ function extractPricePoints(payload: unknown): PricePoint[] {
   if (nested) return extractPricePoints(nested);
   const point = toPricePoint(event);
   return point ? [point] : [];
-}
-
-function mergePricePoints(existing: PricePoint[], incoming: PricePoint[]): PricePoint[] {
-  if (incoming.length === 0) return existing;
-
-  const merged = new Map<number, PricePoint>();
-  for (const point of existing) merged.set(point.time, point);
-  for (const point of incoming) merged.set(point.time, point);
-
-  return Array.from(merged.values())
-    .sort((a, b) => a.time - b.time)
-    .slice(-500);
 }
 
 function buildPriceLabels(points: PricePoint[]): number[] {
@@ -321,14 +310,16 @@ const PriceChart = ({ height = 300 }: PriceChartProps) => {
       }
 
       socketUpdateTimeoutRef.current = window.setTimeout(() => {
-        setData((previous) => {
-          const merged = mergePricePoints(previous, pendingDataRef.current);
-          pendingDataRef.current = [];
-          return merged;
-        });
+        const pending = pendingDataRef.current;
+        pendingDataRef.current = [];
+        socketUpdateTimeoutRef.current = null;
+
+        const merged = mergePricePoints(dataRef.current, pending);
+        if (merged === dataRef.current) return;
+
+        setData(merged);
         setLoadError(null);
         setLastUpdatedAt(new Date());
-        socketUpdateTimeoutRef.current = null;
       }, 50); // 50ms throttle - batch rapid updates
     });
 


### PR DESCRIPTION

Issue 1 — PriceChart unnecessary rerenders on socket merges
File: src/components/PriceChart.tsx

Problem: every batched socket flush produced a brand-new data array (and updated
lastUpdatedAt/loadError), forcing a React rerender + chart redraw even when the
incoming ticks were duplicates of data already on the chart.

Changes:
- mergePricePoints now tracks whether the incoming batch actually changes any
  point (new timestamp, or changed value for an existing timestamp). If nothing
  changes it returns the SAME existing array reference instead of a new one.
- The socket throttle flush now computes the merge against dataRef.current and
  bails out early (no setData / setLoadError / setLastUpdatedAt) when the result
  is referentially equal — so redundant ticks cause zero rerenders.
- Exported mergePricePoints so the behavior is unit-testable.

Result: during a tick stream, batches that don't change the series no longer
trigger a rerender. Real updates still render exactly once (state updates batched).
No change to chart visuals for real updates.

Note: the merge helper was extracted to src/components/PriceChart.helpers.ts
(imported by PriceChart.tsx) so the component file keeps exporting only the
component, satisfying the react-refresh/only-export-components lint rule.

Tests added: src/components/PriceChart.helpers.test.ts
- empty batch returns same reference
- all-duplicate batch returns same reference (the rerender-reduction case)
- new timestamp / changed value return a new array
- output stays sorted and capped at the most recent 500

----------------------------------------------------------------------

Verification status (after `npm ci`):
- Tests: `vitest run` on Navbar.test.tsx + PriceChart.helpers.test.ts → 20/20 pass
  (includes the 4 new tests).
- Lint on the changed files (Navbar.tsx, PriceChart.tsx, PriceChart.helpers.ts,
  and both test files) → clean, no errors/warnings.

Pre-existing failures NOT caused by this PR (untouched files, present on main):
- `npm run lint` errors in src/components/RoundCard.tsx (Date.now purity) and
  src/pages/Dashboard.tsx (setState-in-effect), plus warnings in
  src/hooks/useFocusTrap.ts.
- `npm run build` (tsc) error in src/components/CountdownTimer.tsx
  ("'React' is declared but its value is never read").
These block the repo-wide `pnpm lint` / `pnpm build` gate independently of this
change and should be addressed in separate, focused PRs.

Closes #183 