### PR TITLE
feat: replace landing page hardcoded stats with live network metrics

### DIFF
--- a/src/hooks/useNetworkStats.ts
+++ b/src/hooks/useNetworkStats.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { statsApi, type NetworkStats } from '../lib/api-client';
+import { mockLandingStats } from '../data/mockData';
+
+export interface NetworkStatsState {
+  /** Stats to render. Seeded with mock data so the UI never shows empty values. */
+  stats: NetworkStats;
+  /** True while the first request is in flight. */
+  loading: boolean;
+  /**
+   * True when the displayed numbers are the mock fallback because the API was
+   * unavailable or returned nothing usable.
+   */
+  isStale: boolean;
+}
+
+/**
+ * Fetch live network metrics for the landing page.
+ *
+ * The hook seeds state with {@link mockLandingStats} so the stat cards render at
+ * their final size immediately (no layout shift) while the request resolves. On
+ * success the real values replace the mock; on failure the mock is kept and
+ * `isStale` is set so the UI can show an offline badge.
+ */
+export function useNetworkStats(): NetworkStatsState {
+  const [stats, setStats] = useState<NetworkStats>(mockLandingStats);
+  const [loading, setLoading] = useState(true);
+  const [isStale, setIsStale] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    statsApi
+      .getNetworkStats()
+      .then((live) => {
+        if (!active) return;
+        if (live) {
+          setStats(live);
+          setIsStale(false);
+        } else {
+          setIsStale(true);
+        }
+      })
+      .catch(() => {
+        if (!active) return;
+        setIsStale(true);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return { stats, loading, isStale };
+}

--- a/src/lib/__tests__/network-stats.test.ts
+++ b/src/lib/__tests__/network-stats.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeNetworkStats } from '../api-client';
+
+describe('normalizeNetworkStats', () => {
+  it('reads the canonical key names', () => {
+    expect(
+      normalizeNetworkStats({
+        totalRounds: 1200,
+        vXlmDistributed: 4_200_000,
+        activePlayers: 893,
+      }),
+    ).toEqual({ totalRounds: 1200, vXlmDistributed: 4_200_000, activePlayers: 893 });
+  });
+
+  it('accepts alias key names from the backend', () => {
+    expect(
+      normalizeNetworkStats({
+        roundsResolved: 50,
+        practiceVolume: 1000,
+        activePredictors: 12,
+      }),
+    ).toEqual({ totalRounds: 50, vXlmDistributed: 1000, activePlayers: 12 });
+  });
+
+  it('unwraps a { data } envelope', () => {
+    expect(
+      normalizeNetworkStats({ data: { totalRounds: 7 } }),
+    ).toEqual({ totalRounds: 7, vXlmDistributed: 0, activePlayers: 0 });
+  });
+
+  it('coerces numeric strings', () => {
+    expect(normalizeNetworkStats({ totalRounds: '42' })?.totalRounds).toBe(42);
+  });
+
+  it('returns null when no usable field is present', () => {
+    expect(normalizeNetworkStats({})).toBeNull();
+    expect(normalizeNetworkStats({ unrelated: 'x' })).toBeNull();
+  });
+});

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -173,3 +173,71 @@ export const leaderboardApi = {
         return normalizeLeaderboard(response);
     },
 };
+
+/** Aggregate network metrics shown on the landing page. */
+export interface NetworkStats {
+    /** Total rounds resolved across the platform. */
+    totalRounds: number;
+    /** Total practice volume distributed, in vXLM. */
+    vXlmDistributed: number;
+    /** Count of active predictors. */
+    activePlayers: number;
+}
+
+type NetworkStatsResponse = Record<string, unknown> | { data?: Record<string, unknown> };
+
+function firstFiniteNumber(record: Record<string, unknown>, keys: string[]): number | null {
+    for (const key of keys) {
+        const raw = record[key];
+        const value = typeof raw === 'string' ? Number(raw) : raw;
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return value;
+        }
+    }
+    return null;
+}
+
+/**
+ * Normalize a backend stats payload into {@link NetworkStats}, tolerating the
+ * various key names a backend might use. Returns `null` when no usable numeric
+ * field is present so the caller can fall back to mock data.
+ */
+export function normalizeNetworkStats(response: NetworkStatsResponse): NetworkStats | null {
+    const source =
+        response && typeof response === 'object' && 'data' in response && response.data
+            ? (response.data as Record<string, unknown>)
+            : (response as Record<string, unknown>);
+
+    if (!source || typeof source !== 'object') {
+        return null;
+    }
+
+    const totalRounds = firstFiniteNumber(source, ['totalRounds', 'roundsResolved', 'rounds']);
+    const vXlmDistributed = firstFiniteNumber(source, [
+        'vXlmDistributed',
+        'practiceVolume',
+        'volume',
+    ]);
+    const activePlayers = firstFiniteNumber(source, [
+        'activePlayers',
+        'activePredictors',
+        'players',
+    ]);
+
+    if (totalRounds === null && vXlmDistributed === null && activePlayers === null) {
+        return null;
+    }
+
+    return {
+        totalRounds: totalRounds ?? 0,
+        vXlmDistributed: vXlmDistributed ?? 0,
+        activePlayers: activePlayers ?? 0,
+    };
+}
+
+export const statsApi = {
+    getNetworkStats: async (): Promise<NetworkStats | null> => {
+        const response = await apiFetch<NetworkStatsResponse>('/api/stats/network');
+        return normalizeNetworkStats(response);
+    },
+};

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,20 +1,26 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import HowItWorks from '../components/HowItWorks';
 import ModeCards from '../components/ModeCards';
-import { mockLandingStats } from '../data/mockData';
+import { useNetworkStats } from '../hooks/useNetworkStats';
 
 function useCountUp(target: number, durationMs = 1800) {
   const [value, setValue] = useState(0);
+  // Track the last displayed value so re-targeting (mock -> live stats) animates
+  // smoothly from where it is rather than snapping back to zero.
+  const latestRef = useRef(0);
 
   useEffect(() => {
     let frame = 0;
+    const startValue = latestRef.current;
     const start = performance.now();
 
     const tick = (now: number) => {
       const progress = Math.min((now - start) / durationMs, 1);
       const eased = 1 - Math.pow(1 - progress, 3);
-      setValue(Math.floor(target * eased));
+      const next = Math.floor(startValue + (target - startValue) * eased);
+      latestRef.current = next;
+      setValue(next);
       if (progress < 1) frame = requestAnimationFrame(tick);
     };
 
@@ -34,9 +40,10 @@ function formatStat(value: number, type: 'rounds' | 'vxlm' | 'players') {
 }
 
 export default function Landing() {
-  const rounds = useCountUp(mockLandingStats.totalRounds);
-  const vxlm = useCountUp(mockLandingStats.vXlmDistributed);
-  const players = useCountUp(mockLandingStats.activePlayers);
+  const { stats, isStale } = useNetworkStats();
+  const rounds = useCountUp(stats.totalRounds);
+  const vxlm = useCountUp(stats.vXlmDistributed);
+  const players = useCountUp(stats.activePlayers);
 
   return (
     <div className="xelma-grid-bg min-h-screen text-[#F3F4F6]">
@@ -74,7 +81,21 @@ export default function Landing() {
             New accounts start with 1,000 practice vXLM on Stellar testnet.
           </p>
 
-          <div className="mx-auto mt-16 grid max-w-3xl gap-4 sm:grid-cols-3">
+          {/* Reserved-height row so the badge never shifts the layout on load. */}
+          <div className="mx-auto mt-12 flex h-6 max-w-3xl items-center justify-center">
+            {isStale && (
+              <span
+                className="inline-flex items-center gap-1.5 rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-1 text-xs font-medium text-amber-200"
+                role="status"
+                title="Live metrics are temporarily unavailable. Showing the latest known figures."
+              >
+                <span className="h-1.5 w-1.5 rounded-full bg-amber-400" />
+                Showing cached metrics
+              </span>
+            )}
+          </div>
+
+          <div className="mx-auto mt-4 grid max-w-3xl gap-4 sm:grid-cols-3">
             <div className="glass-card rounded-xl p-5 text-left">
               <p className="text-2xl font-black text-white">{formatStat(rounds, 'rounds')}</p>
               <p className="mt-1 text-xs font-medium uppercase tracking-wider text-[#808897]">


### PR DESCRIPTION
# feat: replace landing page hardcoded stats with live network metrics

Closes #122

## What this does

The landing stat cards (Rounds Resolved, Practice Volume, Active Predictors)
animated hardcoded mock numbers. They now fetch live network metrics from the
backend and fall back to the existing mock values when the API is unavailable.

## Changes

- **`src/lib/api-client.ts`** — new `statsApi.getNetworkStats()` (GET
  `/api/stats/network`) plus an exported, tested `normalizeNetworkStats()` that
  tolerates several backend key names (`totalRounds`/`roundsResolved`/`rounds`,
  `vXlmDistributed`/`practiceVolume`/`volume`, `activePlayers`/`activePredictors`/
  `players`), unwraps a `{ data }` envelope, coerces numeric strings, and returns
  `null` when nothing usable is present.
- **`src/hooks/useNetworkStats.ts`** — seeds state with `mockLandingStats` so the
  cards render at final size immediately, then swaps in live values on success or
  keeps the mock and sets `isStale` on failure.
- **`src/pages/Landing.tsx`** — consumes the hook, keeps the count-up animation
  (now animating smoothly from the current value to the live target instead of
  snapping to zero), and shows a "Showing cached metrics" badge when stale. The
  badge sits in a reserved-height row so it never shifts the layout.
- **`src/lib/__tests__/network-stats.test.ts`** — unit tests for the normalizer.

## Acceptance criteria

- [x] Stats fetched from an API endpoint (`/api/stats/network`).
- [x] Graceful fallback to mock when the API fails (dev included).
- [x] No layout shift on load (cards seeded with fallback; badge in reserved row).
- [x] Copy remains problem-solving focused (no gambling tone; wording unchanged).
- [x] Count-up animation preserved.
- [x] Stale/offline badge when the API is unavailable.

## Verification

- `vitest`: the new normalizer tests pass (5/5).
- `tsc -b`: no new type errors from the changed files.
- `eslint`: clean on all changed files.

> Note: `tsc -b` currently reports one pre-existing error unrelated to this PR
> (`src/components/CountdownTimer.tsx`: unused `React` import) that already fails
> on `main`. It is left untouched to keep this PR scoped to #122.
