### PR TITLE
feat: theme-align Connect page remnants to dark glass terminal

### DIFF
--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -74,13 +74,13 @@ const Connect = () => {
   // Get the feedback icon based on validation state
   const getFeedbackIcon = () => {
     if (isValidating) {
-      return <Loader2 className="w-5 h-5 animate-spin text-blue-500" />;
+      return <Loader2 className="w-5 h-5 animate-spin text-cyan-400" />;
     }
     if (isValid) {
-      return <CheckCircle2 className="w-5 h-5 text-green-500" />;
+      return <CheckCircle2 className="w-5 h-5 text-green-400" />;
     }
     if (state !== 'idle' && state !== 'validating') {
-      return <XCircle className="w-5 h-5 text-red-500" />;
+      return <XCircle className="w-5 h-5 text-red-400" />;
     }
     return null;
   };
@@ -88,30 +88,34 @@ const Connect = () => {
   // Get input border color based on validation state
   const getInputBorderColor = () => {
     if (isValidating) {
-      return 'border-blue-300 focus:border-blue-500 focus:ring-blue-500';
+      return 'border-cyan-500/50 focus:border-cyan-400 focus:ring-cyan-400/30';
     }
     if (isValid) {
-      return 'border-green-300 focus:border-green-500 focus:ring-green-500';
+      return 'border-green-500/50 focus:border-green-400 focus:ring-green-400/30';
     }
     if (state !== 'idle' && state !== 'validating') {
-      return 'border-red-300 focus:border-red-500 focus:ring-red-500';
+      return 'border-red-500/50 focus:border-red-400 focus:ring-red-400/30';
     }
-    return 'border-gray-300 focus:border-blue-500 focus:ring-blue-500';
+    return 'border-gray-700 focus:border-[#2C4BFD] focus:ring-[#2C4BFD]/30';
   };
 
   return (
-    <div className="min-h-screen bg-[#FAFAFA] dark:bg-gray-900 flex items-center justify-center px-4 py-12">
-      <div className="w-full max-w-md">
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8">
+    <div className="xelma-grid-bg min-h-screen relative flex items-center justify-center overflow-hidden px-4 py-12">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,_rgba(44,75,253,0.15),_transparent_60%)]" />
+      <div className="pointer-events-none absolute -left-24 top-32 h-80 w-80 rounded-full bg-cyan-500/5 blur-3xl" />
+      <div className="pointer-events-none absolute -right-24 top-16 h-96 w-96 rounded-full bg-[#2C4BFD]/8 blur-3xl" />
+
+      <div className="relative z-10 w-full max-w-md">
+        <div className="glass-card rounded-2xl p-8">
           <div className="flex items-center gap-3 mb-6">
-            <div className="w-12 h-12 rounded-full bg-gradient-to-tr from-blue-500 to-purple-500 flex items-center justify-center">
+            <div className="w-12 h-12 rounded-full bg-gradient-to-tr from-[#2C4BFD] to-[#22D3EE] flex items-center justify-center">
               <Wallet className="w-6 h-6 text-white" />
             </div>
             <div>
-              <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+              <h1 className="text-2xl font-bold text-white">
                 Connect Wallet
               </h1>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
+              <p className="text-sm text-gray-400">
                 Connect your Freighter wallet to get started
               </p>
             </div>
@@ -124,7 +128,7 @@ const Connect = () => {
               <button
                 type="button"
                 onClick={() => navigate('/dashboard')}
-                className="mt-4 w-full px-4 py-3 rounded-lg font-semibold bg-[#2C4BFD] hover:bg-[#1a3bf0] text-white shadow-lg shadow-blue-500/20 transition-all duration-200"
+                className="btn-primary mt-4 w-full rounded-xl px-4 py-3 text-sm font-bold"
               >
                 Continue to Dashboard
               </button>
@@ -132,11 +136,11 @@ const Connect = () => {
           </div>
 
           {/* Advanced path toggle: optional manual address validation */}
-          <div className="border-t border-gray-200 dark:border-gray-700 pt-4">
+          <div className="border-t border-[#BEC7FE]/10 pt-4">
             <button
               type="button"
               onClick={() => setShowAdvanced((v) => !v)}
-              className="flex w-full items-center justify-between text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
+              className="flex w-full items-center justify-between text-sm font-medium text-gray-400 hover:text-white transition-colors"
               aria-expanded={showAdvanced}
             >
               <span>Advanced: validate an address manually</span>
@@ -152,7 +156,7 @@ const Connect = () => {
           <>
           {/* Network Selection */}
           <div className="mb-6 mt-4">
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            <label className="block text-sm font-medium text-gray-400 mb-2">
               Network
             </label>
             <div className="flex gap-2">
@@ -162,8 +166,8 @@ const Connect = () => {
                 className={clsx(
                   'flex-1 px-4 py-2 rounded-lg font-medium transition-all',
                   selectedNetwork === 'MAINNET'
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
+                    ? 'bg-[#2C4BFD] text-white'
+                    : 'bg-white/5 text-gray-400 hover:bg-white/10 hover:text-white'
                 )}
               >
                 Mainnet
@@ -174,8 +178,8 @@ const Connect = () => {
                 className={clsx(
                   'flex-1 px-4 py-2 rounded-lg font-medium transition-all',
                   selectedNetwork === 'TESTNET'
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
+                    ? 'bg-[#2C4BFD] text-white'
+                    : 'bg-white/5 text-gray-400 hover:bg-white/10 hover:text-white'
                 )}
               >
                 Testnet
@@ -187,7 +191,7 @@ const Connect = () => {
           <div className="mb-4">
             <label
               htmlFor="stellar-address"
-              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+              className="block text-sm font-medium text-gray-400 mb-2"
             >
               Stellar Address
             </label>
@@ -202,7 +206,7 @@ const Connect = () => {
                 placeholder="GABCDEFGHIJKLMNOPQRSTUVWXYZ..."
                 className={clsx(
                   'w-full px-4 py-3 pr-12 rounded-lg border-2 focus:outline-none focus:ring-2 transition-all',
-                  'bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500',
+                  'bg-gray-950 text-white placeholder-gray-500',
                   getInputBorderColor()
                 )}
                 maxLength={56}
@@ -216,7 +220,7 @@ const Connect = () => {
 
             {/* Error Message */}
             {errorMessage && (
-              <div className="mt-2 flex items-start gap-2 text-sm text-red-600 dark:text-red-400">
+              <div className="mt-2 flex items-start gap-2 text-sm text-red-400">
                 <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
                 <span>{errorMessage}</span>
               </div>
@@ -224,7 +228,7 @@ const Connect = () => {
 
             {/* Success Message */}
             {isValid && (
-              <div className="mt-2 flex items-start gap-2 text-sm text-green-600 dark:text-green-400">
+              <div className="mt-2 flex items-start gap-2 text-sm text-green-400">
                 <CheckCircle2 className="w-4 h-4 mt-0.5 flex-shrink-0" />
                 <span>Address is valid and exists on {selectedNetwork}</span>
               </div>
@@ -232,7 +236,7 @@ const Connect = () => {
 
             {/* Helper Text */}
             {state === 'idle' && (
-              <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+              <p className="mt-2 text-xs text-gray-500">
                 Enter a 56-character Stellar address (starts with G for Mainnet)
               </p>
             )}
@@ -247,8 +251,8 @@ const Connect = () => {
               'w-full px-4 py-3 rounded-lg font-semibold transition-all duration-200',
               'flex items-center justify-center gap-2',
               isValid && !isValidating
-                ? 'bg-[#2C4BFD] hover:bg-[#1a3bf0] text-white shadow-lg shadow-blue-500/20 cursor-pointer'
-                : 'bg-gray-300 dark:bg-gray-600 text-gray-500 dark:text-gray-400 cursor-not-allowed'
+                ? 'bg-[#2C4BFD] hover:bg-[#1a3bf0] text-white cursor-pointer'
+                : 'bg-white/10 text-gray-500 cursor-not-allowed'
             )}
           >
             {isValidating ? (


### PR DESCRIPTION
Migrate Connect page from light #FAFAFA / white-card remnants to match the dark glass terminal theme used across Landing and Dashboard.

Changes:
- Replace bg-[#FAFAFA] outer container with xelma-grid-bg + ambient glow divs for visual parity with Landing
- Swap bg-white dark:bg-gray-800 card for glass-card rounded-2xl
- Remove all dark: variant classes in favor of explicit dark-theme colors matching xelma design system
- Update text colors: text-gray-900 -> text-white, text-gray-500/600 ->
  text-gray-400, etc
- Fix input styling: bg-white -> bg-gray-950, proper dark border colors with reduced opacity (border-*-500/50)
- Refresh network toggle buttons: active uses bg-[#2C4BFD], inactive uses bg-white/5 with hover states
- Update icon colors to -400 variants for dark background contrast
- Replace Continue button inline styles with btn-primary class
- Replace header gradient with xelma brand gradient (blue -> teal)
- Keep Freighter wallet primary path (WalletConnect) completely intact

Closes: theme-align-connect

Closes #326 