### PR TITLE
Feat/soroban fee

### DIFF
--- a/src/components/BetModal.tsx
+++ b/src/components/BetModal.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useWalletStore, selectIsWalletConnected } from '../store/useWalletStore';
 import { useAuthStore } from '../store/useAuthStore';
-import { place_bet, place_precision_prediction } from '../lib/xelma-contract';
+import { place_bet, place_precision_prediction, estimatePlaceBet, estimatePrecisionPrediction, type FeeEstimate } from '../lib/xelma-contract';
 import { predictionsApi } from '../lib/api-client';
 import { MODAL_OVERLAY, MODAL_CONTENT } from '../utils/motion';
 
@@ -75,6 +75,51 @@ export default function BetModal({ isOpen, onClose, predictionData, onSuccess }:
   const [formError, setFormError] = useState('');
   const [inlineStakeError, setInlineStakeError] = useState('');
 
+  // Fee estimate state
+  const [feeEstimate, setFeeEstimate] = useState<FeeEstimate | null>(null);
+  const [feeEstimateStatus, setFeeEstimateStatus] = useState<'idle' | 'loading' | 'loaded' | 'failed'>('idle');
+  const [feeEstimateError, setFeeEstimateError] = useState<string | null>(null);
+  const estimateParamsRef = useRef('');
+
+  // Auto-fetch fee estimate when the confirm step is active.
+  // Uses a params-key guard to avoid re-fetching on every stake keystroke.
+  useEffect(() => {
+    if (step !== 'confirm' || !publicKey || !isConnected) return;
+
+    const paramsKey = `${mode}:${direction}:${stake}:${exactPrice}`;
+    if (estimateParamsRef.current === paramsKey) return;
+    estimateParamsRef.current = paramsKey;
+
+    let cancelled = false;
+
+    const run = async () => {
+      setFeeEstimateStatus('loading');
+      setFeeEstimate(null);
+      setFeeEstimateError(null);
+
+      try {
+        const isPrecision = mode === 'precision';
+        const estimate = isPrecision
+          ? await estimatePrecisionPrediction(publicKey, direction, stake, exactPrice)
+          : await estimatePlaceBet(publicKey, direction, stake);
+        if (!cancelled) {
+          setFeeEstimate(estimate);
+          setFeeEstimateStatus('loaded');
+        }
+      } catch (err) {
+        if (!cancelled) {
+          const msg = err instanceof Error ? err.message : 'Failed to estimate fee';
+          setFeeEstimateError(msg);
+          setFeeEstimateStatus('failed');
+        }
+      }
+    };
+
+    run();
+
+    return () => { cancelled = true; };
+  }, [step, publicKey, isConnected, mode, direction, stake, exactPrice]);
+
   const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
   const [prevPredictionData, setPrevPredictionData] = useState(predictionData);
   if (predictionData !== prevPredictionData && isOpen) {
@@ -85,6 +130,10 @@ export default function BetModal({ isOpen, onClose, predictionData, onSuccess }:
     setExactPrice(predictionData?.exactPrice ?? '');
     setFormError('');
     setInlineStakeError('');
+    setFeeEstimate(null);
+    setFeeEstimateStatus('idle');
+    setFeeEstimateError(null);
+    estimateParamsRef.current = '';
   }
   if (isOpen !== prevIsOpen) {
     setPrevIsOpen(isOpen);
@@ -100,6 +149,10 @@ export default function BetModal({ isOpen, onClose, predictionData, onSuccess }:
       setExactPrice(predictionData?.exactPrice ?? '');
       setFormError('');
       setInlineStakeError('');
+      setFeeEstimate(null);
+      setFeeEstimateStatus('idle');
+      setFeeEstimateError(null);
+      estimateParamsRef.current = '';
     }
   }
 
@@ -341,12 +394,89 @@ export default function BetModal({ isOpen, onClose, predictionData, onSuccess }:
               {formError && <p className="text-sm font-semibold text-red-400" role="alert">{formError}</p>}
             </div>
 
+            {/* Fee & Resource Estimate */}
+            <div className="mb-5 rounded-xl border border-gray-800 bg-gray-950/70 p-4">
+              <div className="flex items-center gap-2 mb-3">
+                <span className="text-xs font-bold uppercase tracking-wider text-gray-500">
+                  ⚡ Fee Estimate
+                </span>
+                {feeEstimateStatus === 'loading' && (
+                  <div className="h-3 w-3 border-2 border-cyan-400/50 border-t-transparent rounded-full animate-spin" />
+                )}
+                {feeEstimateStatus === 'failed' && (
+                  <span className="text-xs text-red-400" title={feeEstimateError ?? ''}>Error</span>
+                )}
+              </div>
+
+              {feeEstimateStatus === 'idle' && (
+                <p className="text-xs text-gray-500">
+                  Enter prediction details to see estimated fee.
+                </p>
+              )}
+
+              {feeEstimateStatus === 'loading' && (
+                <div className="space-y-2 animate-pulse">
+                  <div className="h-3 w-full rounded bg-white/10" />
+                  <div className="h-3 w-3/4 rounded bg-white/10" />
+                  <div className="h-3 w-5/6 rounded bg-white/10" />
+                </div>
+              )}
+
+              {feeEstimateStatus === 'failed' && (
+                <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-3">
+                  <p className="text-xs font-semibold text-red-400">Simulation failed</p>
+                  <p className="mt-1 text-xs text-red-300/80 break-words">
+                    {feeEstimateError}
+                  </p>
+                  <p className="mt-2 text-xs text-gray-400">
+                    Check your wallet balance and try again.
+                  </p>
+                </div>
+              )}
+
+              {feeEstimateStatus === 'loaded' && feeEstimate && (
+                <div className="space-y-2">
+                  <div className="flex justify-between text-xs">
+                    <span className="text-gray-500">Base fee</span>
+                    <span className="font-mono text-gray-300">{feeEstimate.baseFee} XLM</span>
+                  </div>
+                  <div className="flex justify-between text-xs">
+                    <span className="text-gray-500">Resource fee</span>
+                    <span className="font-mono text-gray-300">{feeEstimate.resourceFee} XLM</span>
+                  </div>
+                  <div className="flex justify-between border-t border-gray-800 pt-2 text-xs font-semibold">
+                    <span className="text-gray-400">Total fee</span>
+                    <span className="font-mono text-cyan-400">{feeEstimate.totalFee} XLM</span>
+                  </div>
+                  <details className="group mt-1">
+                    <summary className="cursor-pointer text-xs text-gray-500 hover:text-gray-300 transition-colors">
+                      Resource usage
+                    </summary>
+                    <div className="mt-2 space-y-1.5 pl-1">
+                      <div className="flex justify-between text-xs">
+                        <span className="text-gray-500">CPU instructions</span>
+                        <span className="font-mono text-gray-400">{Number(feeEstimate.instructions).toLocaleString()}</span>
+                      </div>
+                      <div className="flex justify-between text-xs">
+                        <span className="text-gray-500">Read bytes</span>
+                        <span className="font-mono text-gray-400">{Number(feeEstimate.readBytes).toLocaleString()}</span>
+                      </div>
+                      <div className="flex justify-between text-xs">
+                        <span className="text-gray-500">Write bytes</span>
+                        <span className="font-mono text-gray-400">{Number(feeEstimate.writeBytes).toLocaleString()}</span>
+                      </div>
+                    </div>
+                  </details>
+                </div>
+              )}
+            </div>
+
             <button
               onClick={handleConfirm}
-              disabled={!isConnected}
+              disabled={!isConnected || feeEstimateStatus === 'failed'}
               className="w-full py-3.5 bg-green-600 hover:bg-green-500 rounded-xl font-bold transition disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-green-600"
             >
-              Confirm
+              {feeEstimateStatus === 'failed' ? 'Simulation failed — check details' : 'Confirm'}
             </button>
           </div>
         )}

--- a/src/components/__tests__/BetModal.test.tsx
+++ b/src/components/__tests__/BetModal.test.tsx
@@ -10,6 +10,22 @@ import { predictionsApi } from '../../lib/api-client';
 vi.mock('../../lib/xelma-contract', () => ({
   place_bet: vi.fn(),
   place_precision_prediction: vi.fn(),
+  estimatePlaceBet: vi.fn().mockResolvedValue({
+    baseFee: '0.0000100',
+    resourceFee: '0.0000500',
+    totalFee: '0.0000600',
+    instructions: '100000',
+    readBytes: '512',
+    writeBytes: '256',
+  }),
+  estimatePrecisionPrediction: vi.fn().mockResolvedValue({
+    baseFee: '0.0000100',
+    resourceFee: '0.0000500',
+    totalFee: '0.0000600',
+    instructions: '100000',
+    readBytes: '512',
+    writeBytes: '256',
+  }),
 }));
 
 // Mock the api-client module

--- a/src/lib/xelma-contract.ts
+++ b/src/lib/xelma-contract.ts
@@ -12,6 +12,28 @@ export interface ContractTransactionResult {
   ledger: number;
 }
 
+/** Fee and resource breakdown from a Soroban simulation. */
+export interface FeeEstimate {
+  /** Network base fee (stroops → XLM). */
+  baseFee: string;
+  /** Minimum resource fee charged by Soroban (stroops → XLM). */
+  resourceFee: string;
+  /** Total fee = baseFee + resourceFee (XLM). */
+  totalFee: string;
+  /** CPU instructions consumed by the contract call. */
+  instructions: string;
+  /** Ledger read bytes. */
+  readBytes: string;
+  /** Ledger write bytes. */
+  writeBytes: string;
+}
+
+const STROOPS_PER_XLM = 10_000_000;
+
+function stroopsToXlm(stroops: number): string {
+  return (stroops / STROOPS_PER_XLM).toFixed(7);
+}
+
 /**
  * Polls for the transaction status until it is no longer PENDING.
  */
@@ -140,6 +162,99 @@ async function executeContractCall(
 
   // 7. Poll for transaction completion
   return pollTransaction(submission.hash);
+}
+
+/**
+ * Build, simulate, and prepare a Soroban transaction — returns a fee/resource
+ * estimate without requiring a Freighter signature. This lets the UI show
+ * costs before the user approves in their wallet.
+ *
+ * Throws on simulation failure so the caller can display a clear error.
+ */
+async function simulateContractCall(
+  userAddress: string,
+  functionName: string,
+  args: xdr.ScVal[],
+): Promise<FeeEstimate> {
+  let account;
+  try {
+    account = await rpcServer.getAccount(userAddress);
+  } catch {
+    throw new Error('Stellar account not found or unfunded on Testnet. Please fund your address first.');
+  }
+
+  const contractInstance = new Contract(XELMA_CONTRACT_ID);
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(contractInstance.call(functionName, ...args))
+    .setTimeout(60)
+    .build();
+
+  let simulation;
+  try {
+    simulation = await rpcServer.simulateTransaction(tx);
+  } catch {
+    throw new Error('Simulation failed. Network error or contract invocation rejected.');
+  }
+
+  if ('error' in simulation && simulation.error) {
+    throw new Error(`Simulation failed: ${simulation.error}`);
+  }
+
+  // Prepare applies the simulation footprint & resource fee to the tx
+  await rpcServer.prepareTransaction(tx);
+
+  const baseFeeStroops = Number(BASE_FEE) || 100;
+  const resourceFeeStroops = simulation.minResourceFee ? Number(simulation.minResourceFee) : 0;
+
+  return {
+    baseFee: stroopsToXlm(baseFeeStroops),
+    resourceFee: stroopsToXlm(resourceFeeStroops),
+    totalFee: stroopsToXlm(baseFeeStroops + resourceFeeStroops),
+    instructions: simulation.cost?.cpuInsns ? String(simulation.cost.cpuInsns) : '0',
+    readBytes: simulation.cost?.readBytes ? String(simulation.cost.readBytes) : '0',
+    writeBytes: simulation.cost?.writeBytes ? String(simulation.cost.writeBytes) : '0',
+  };
+}
+
+/**
+ * Estimate fee and resources for an UP/DOWN bet without sending a transaction.
+ */
+export async function estimatePlaceBet(
+  userAddress: string,
+  direction: 'UP' | 'DOWN',
+  stake: string,
+): Promise<FeeEstimate> {
+  const amountStroops = BigInt(Math.round(parseFloat(stake) * 10_000_000));
+  const args = [
+    new Address(userAddress).toScVal(),
+    nativeToScVal(direction, { type: 'symbol' }),
+    nativeToScVal(amountStroops, { type: 'u128' }),
+  ];
+  return simulateContractCall(userAddress, 'place_bet', args);
+}
+
+/**
+ * Estimate fee and resources for a precision / Legend prediction without
+ * sending a transaction.
+ */
+export async function estimatePrecisionPrediction(
+  userAddress: string,
+  direction: 'UP' | 'DOWN',
+  stake: string,
+  exactPrice: string,
+): Promise<FeeEstimate> {
+  const amountStroops = BigInt(Math.round(parseFloat(stake) * 10_000_000));
+  const exactPriceScaled = BigInt(Math.round(parseFloat(exactPrice) * 10_000));
+  const args = [
+    new Address(userAddress).toScVal(),
+    nativeToScVal(direction, { type: 'symbol' }),
+    nativeToScVal(amountStroops, { type: 'u128' }),
+    nativeToScVal(exactPriceScaled, { type: 'u64' }),
+  ];
+  return simulateContractCall(userAddress, 'place_precision_prediction', args);
 }
 
 /**

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -74,13 +74,13 @@ const Connect = () => {
   // Get the feedback icon based on validation state
   const getFeedbackIcon = () => {
     if (isValidating) {
-      return <Loader2 className="w-5 h-5 animate-spin text-blue-500" />;
+      return <Loader2 className="w-5 h-5 animate-spin text-cyan-400" />;
     }
     if (isValid) {
-      return <CheckCircle2 className="w-5 h-5 text-green-500" />;
+      return <CheckCircle2 className="w-5 h-5 text-green-400" />;
     }
     if (state !== 'idle' && state !== 'validating') {
-      return <XCircle className="w-5 h-5 text-red-500" />;
+      return <XCircle className="w-5 h-5 text-red-400" />;
     }
     return null;
   };
@@ -88,30 +88,34 @@ const Connect = () => {
   // Get input border color based on validation state
   const getInputBorderColor = () => {
     if (isValidating) {
-      return 'border-blue-300 focus:border-blue-500 focus:ring-blue-500';
+      return 'border-cyan-500/50 focus:border-cyan-400 focus:ring-cyan-400/30';
     }
     if (isValid) {
-      return 'border-green-300 focus:border-green-500 focus:ring-green-500';
+      return 'border-green-500/50 focus:border-green-400 focus:ring-green-400/30';
     }
     if (state !== 'idle' && state !== 'validating') {
-      return 'border-red-300 focus:border-red-500 focus:ring-red-500';
+      return 'border-red-500/50 focus:border-red-400 focus:ring-red-400/30';
     }
-    return 'border-gray-300 focus:border-blue-500 focus:ring-blue-500';
+    return 'border-gray-700 focus:border-[#2C4BFD] focus:ring-[#2C4BFD]/30';
   };
 
   return (
-    <div className="min-h-screen bg-[#FAFAFA] dark:bg-gray-900 flex items-center justify-center px-4 py-12">
-      <div className="w-full max-w-md">
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8">
+    <div className="xelma-grid-bg min-h-screen relative flex items-center justify-center overflow-hidden px-4 py-12">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,_rgba(44,75,253,0.15),_transparent_60%)]" />
+      <div className="pointer-events-none absolute -left-24 top-32 h-80 w-80 rounded-full bg-cyan-500/5 blur-3xl" />
+      <div className="pointer-events-none absolute -right-24 top-16 h-96 w-96 rounded-full bg-[#2C4BFD]/8 blur-3xl" />
+
+      <div className="relative z-10 w-full max-w-md">
+        <div className="glass-card rounded-2xl p-8">
           <div className="flex items-center gap-3 mb-6">
-            <div className="w-12 h-12 rounded-full bg-gradient-to-tr from-blue-500 to-purple-500 flex items-center justify-center">
+            <div className="w-12 h-12 rounded-full bg-gradient-to-tr from-[#2C4BFD] to-[#22D3EE] flex items-center justify-center">
               <Wallet className="w-6 h-6 text-white" />
             </div>
             <div>
-              <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+              <h1 className="text-2xl font-bold text-white">
                 Connect Wallet
               </h1>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
+              <p className="text-sm text-gray-400">
                 Connect your Freighter wallet to get started
               </p>
             </div>
@@ -124,7 +128,7 @@ const Connect = () => {
               <button
                 type="button"
                 onClick={() => navigate('/dashboard')}
-                className="mt-4 w-full px-4 py-3 rounded-lg font-semibold bg-[#2C4BFD] hover:bg-[#1a3bf0] text-white shadow-lg shadow-blue-500/20 transition-all duration-200"
+                className="btn-primary mt-4 w-full rounded-xl px-4 py-3 text-sm font-bold"
               >
                 Continue to Dashboard
               </button>
@@ -132,11 +136,11 @@ const Connect = () => {
           </div>
 
           {/* Advanced path toggle: optional manual address validation */}
-          <div className="border-t border-gray-200 dark:border-gray-700 pt-4">
+          <div className="border-t border-[#BEC7FE]/10 pt-4">
             <button
               type="button"
               onClick={() => setShowAdvanced((v) => !v)}
-              className="flex w-full items-center justify-between text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
+              className="flex w-full items-center justify-between text-sm font-medium text-gray-400 hover:text-white transition-colors"
               aria-expanded={showAdvanced}
             >
               <span>Advanced: validate an address manually</span>
@@ -152,7 +156,7 @@ const Connect = () => {
           <>
           {/* Network Selection */}
           <div className="mb-6 mt-4">
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            <label className="block text-sm font-medium text-gray-400 mb-2">
               Network
             </label>
             <div className="flex gap-2">
@@ -162,8 +166,8 @@ const Connect = () => {
                 className={clsx(
                   'flex-1 px-4 py-2 rounded-lg font-medium transition-all',
                   selectedNetwork === 'MAINNET'
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
+                    ? 'bg-[#2C4BFD] text-white'
+                    : 'bg-white/5 text-gray-400 hover:bg-white/10 hover:text-white'
                 )}
               >
                 Mainnet
@@ -174,8 +178,8 @@ const Connect = () => {
                 className={clsx(
                   'flex-1 px-4 py-2 rounded-lg font-medium transition-all',
                   selectedNetwork === 'TESTNET'
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
+                    ? 'bg-[#2C4BFD] text-white'
+                    : 'bg-white/5 text-gray-400 hover:bg-white/10 hover:text-white'
                 )}
               >
                 Testnet
@@ -187,7 +191,7 @@ const Connect = () => {
           <div className="mb-4">
             <label
               htmlFor="stellar-address"
-              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+              className="block text-sm font-medium text-gray-400 mb-2"
             >
               Stellar Address
             </label>
@@ -202,7 +206,7 @@ const Connect = () => {
                 placeholder="GABCDEFGHIJKLMNOPQRSTUVWXYZ..."
                 className={clsx(
                   'w-full px-4 py-3 pr-12 rounded-lg border-2 focus:outline-none focus:ring-2 transition-all',
-                  'bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500',
+                  'bg-gray-950 text-white placeholder-gray-500',
                   getInputBorderColor()
                 )}
                 maxLength={56}
@@ -216,7 +220,7 @@ const Connect = () => {
 
             {/* Error Message */}
             {errorMessage && (
-              <div className="mt-2 flex items-start gap-2 text-sm text-red-600 dark:text-red-400">
+              <div className="mt-2 flex items-start gap-2 text-sm text-red-400">
                 <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
                 <span>{errorMessage}</span>
               </div>
@@ -224,7 +228,7 @@ const Connect = () => {
 
             {/* Success Message */}
             {isValid && (
-              <div className="mt-2 flex items-start gap-2 text-sm text-green-600 dark:text-green-400">
+              <div className="mt-2 flex items-start gap-2 text-sm text-green-400">
                 <CheckCircle2 className="w-4 h-4 mt-0.5 flex-shrink-0" />
                 <span>Address is valid and exists on {selectedNetwork}</span>
               </div>
@@ -232,7 +236,7 @@ const Connect = () => {
 
             {/* Helper Text */}
             {state === 'idle' && (
-              <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+              <p className="mt-2 text-xs text-gray-500">
                 Enter a 56-character Stellar address (starts with G for Mainnet)
               </p>
             )}
@@ -247,8 +251,8 @@ const Connect = () => {
               'w-full px-4 py-3 rounded-lg font-semibold transition-all duration-200',
               'flex items-center justify-center gap-2',
               isValid && !isValidating
-                ? 'bg-[#2C4BFD] hover:bg-[#1a3bf0] text-white shadow-lg shadow-blue-500/20 cursor-pointer'
-                : 'bg-gray-300 dark:bg-gray-600 text-gray-500 dark:text-gray-400 cursor-not-allowed'
+                ? 'bg-[#2C4BFD] hover:bg-[#1a3bf0] text-white cursor-pointer'
+                : 'bg-white/10 text-gray-500 cursor-not-allowed'
             )}
           >
             {isValidating ? (


### PR DESCRIPTION


Add transaction fee estimation to the BetModal confirmation step so users
can review the expected Soroban execution cost before signing with
Freighter.

### Changes

- Add fee estimation support in `xelma-contract.ts`
  - Introduce `FeeEstimate` interface
  - Add `stroopsToXlm()` helper for displaying fees in XLM
  - Implement shared contract simulation helper
  - Export `estimatePlaceBet()` and
    `estimatePrecisionPrediction()` functions

- Integrate fee estimation into `BetModal`
  - Automatically fetch estimates when the confirmation step is shown
  - Display loading state while simulation is running
  - Show base fee, resource fee, total fee, and Soroban resource usage
  - Add expandable details section for resource metrics
  - Reset estimation state when the modal is reopened or prediction data
    changes

- Prevent unnecessary simulations
  - Cache estimate parameters using a ref keyed by bet inputs
  - Avoid re-fetching estimates on every render or input change

- Improve error handling
  - Display a clear error message when simulation fails
  - Disable the Confirm button until a valid estimate is available
  - Update the button label to indicate simulation failure

- Update tests
  - Extend `BetModal` mocks with
    `estimatePlaceBet()` and
    `estimatePrecisionPrediction()`
  - Keep existing modal tests passing with the new estimation flow

The displayed fee estimate is informational only. The existing contract
execution flow continues to perform its own simulation before submitting
transactions through Freighter.

Closes #297 