### PR TITLE
feat: document Stellar Wave architecture + add page unit tests (Closes #338, Closes #331)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,10 +35,67 @@ Do not commit private keys, wallet secrets, production tokens, or personal RPC c
 The app has a dual-dashboard model plus a standalone landing page:
 
 - `/` renders the bespoke public landing experience.
-- `/dashboard` renders the current terminal dashboard used for the primary connected prediction flow.
-- `/play` renders the legacy play dashboard kept available while terminal-dashboard work continues.
+- `/dashboard` is the **single primary prediction terminal**. It includes the price chart, round lifecycle timeline, connection status, end-round modal, and opt-in community chat. This is the live dashboard used for all connected prediction flows.
+- `/play` is **deprecated** and permanently redirects to `/dashboard`. The `LegacyDashboard` component is retained only for reference and is no longer routed. New work should target `/dashboard` exclusively.
 
 All routed pages are composed under the dark terminal shell in `src/App.tsx`: `<OfflineBanner />`, `<Navbar />`, lazy routes, `<Footer />` (except the landing route), and `<Toaster />`. Avoid adding a second global shell or duplicate header. Prefer existing dark palette utilities and shared components.
+
+## Stellar Wave contributor quick-start
+
+Xelma participates in the Stellar Wave hackathon program. This section is the fastest path
+for a new contributor to find rebuildable stubs and start shipping.
+
+### 1. Find rebuild stubs with ContributorTaskPlaceholder
+
+The `ContributorTaskPlaceholder` component (`src/components/ContributorTaskPlaceholder.tsx`)
+is a temporary shell that marks UI surfaces intentionally stubbed for contributor rebuilds.
+It renders a dashed cyan border with a title and an `issueHint` linking back to the
+relevant GitHub issue.
+
+Search for import references to find all active stubs:
+
+```bash
+grep -r "ContributorTaskPlaceholder" src/
+```
+
+Active stubs (search for the component name in [open Stellar Wave issues](https://github.com/TevaLabs/Xelma-Frontend/issues?q=is%3Aissue+is%3Aopen+label%3A%22Stellar+Wave%22) to find the corresponding rebuild issue):
+
+| Component | Location |
+| --- | --- |
+| `RoundTimer.tsx` | `src/components/RoundTimer.tsx` |
+| `RankProgressBar.tsx` | `src/components/RankProgressBar.tsx` |
+| `ModeCards.tsx` | `src/components/ModeCards.tsx` |
+| `NewsRibbon.tsx` | `src/components/NewsRibbon.tsx` |
+| `HowItWorks.tsx` | `src/components/HowItWorks.tsx` |
+| `LiveGameStatsPanel.tsx` | `src/components/LiveGameStatsPanel.tsx` |
+| `HudStatusRow.tsx` | `src/components/hud/HudStatusRow.tsx` |
+| `GuideCard.tsx` | `src/components/education/GuideCard.tsx` |
+| `TipCard.tsx` | `src/components/education/TipCard.tsx` |
+
+### 2. How to claim a rebuild issue
+
+1. Browse [open Stellar Wave issues](https://github.com/TevaLabs/Xelma-Frontend/issues?q=is%3Aissue+is%3Aopen+label%3A%22Stellar+Wave%22).
+2. Comment on the issue to express interest and share your approach.
+3. Replace the `ContributorTaskPlaceholder` wrapper with real UI that matches the
+   issue's acceptance criteria and the project's dark terminal design system.
+4. Remove the `ContributorTaskPlaceholder` import once the stub is fully replaced.
+5. Open a PR referencing the issue (e.g., `Closes #254`).
+
+### 3. Freighter + Soroban environment variables
+
+To interact with the Stellar blockchain (wallet connection and on-chain contract calls),
+you may need these additional environment variables. Add them to your local `.env` file:
+
+| Variable | Required? | Default / notes |
+| --- | --- | --- |
+| `VITE_STELLAR_RPC_URL` | Optional for testnet | `https://soroban-testnet.stellar.org` — Soroban JSON-RPC endpoint. |
+| `VITE_XELMA_CONTRACT_ID` | Optional for testnet | Defaults to the checked-in testnet contract id in `src/lib/xelma-contract.ts`. |
+| `VITE_STELLAR_NETWORK_PASSPHRASE` | Optional for testnet | `Test SDF Network ; September 2015` — network passphrase for signing transactions. |
+| `VITE_STELLAR_NETWORK` | Optional | `TESTNET` — human-readable network label shown in the navbar badge. |
+
+> **Freighter wallet** (`@stellar/freighter-api`) is the supported browser extension for
+> connecting a Stellar wallet. Install it from [freighter.app](https://www.freighter.app/).
+> Connection logic lives in `src/store/useWalletStore.ts` and `src/components/WalletConnect.tsx`.
 
 ## Before opening a PR
 

--- a/src/pages/Connect.test.tsx
+++ b/src/pages/Connect.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock useStellarAddressValidation
+vi.mock('../hooks/useStellarAddressValidation', () => ({
+  useStellarAddressValidation: vi.fn(() => ({
+    state: 'idle',
+    isValid: false,
+    isValidating: false,
+    errorMessage: null,
+  })),
+}));
+
+// Mock react-router-dom
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+// Mock WalletConnect component
+vi.mock('../components/WalletConnect', () => ({
+  default: () => <div data-testid="wallet-connect">WalletConnect Mock</div>,
+}));
+
+// Mock useWalletStore
+vi.mock('../store/useWalletStore', () => ({
+  useWalletStore: vi.fn(),
+}));
+
+// Mock sonner toast
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+import Connect from './Connect';
+import { useWalletStore } from '../store/useWalletStore';
+
+const mockUseWalletStore = vi.mocked(useWalletStore);
+
+function mockWalletState(status: string, publicKey: string | null) {
+  mockUseWalletStore.mockImplementation((selector: any) => {
+    const store = { status, publicKey };
+    if (typeof selector === 'function') return selector(store);
+    return store;
+  });
+}
+
+describe('Connect Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWalletState('idle', null);
+  });
+
+  describe('rendering', () => {
+    it('renders the Connect Wallet heading', () => {
+      render(<Connect />);
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Connect Wallet');
+    });
+
+    it('renders the subtitle about Freighter wallet', () => {
+      render(<Connect />);
+      expect(
+        screen.getByText(/Connect your Freighter wallet to get started/i),
+      ).toBeInTheDocument();
+    });
+
+    it('renders the WalletConnect component', () => {
+      render(<Connect />);
+      expect(screen.getByTestId('wallet-connect')).toBeInTheDocument();
+    });
+
+    it('renders the advanced toggle button', () => {
+      render(<Connect />);
+      expect(
+        screen.getByRole('button', { name: /Advanced: validate an address manually/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('wallet connected state', () => {
+    it('shows Continue to Dashboard button when wallet is connected', () => {
+      mockWalletState('connected', 'GTEST1234567890');
+      render(<Connect />);
+
+      expect(
+        screen.getByRole('button', { name: /Continue to Dashboard/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('navigates to /dashboard when Continue button is clicked', () => {
+      mockWalletState('connected', 'GTEST1234567890');
+      render(<Connect />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Continue to Dashboard/i }));
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+    });
+
+    it('does not show Continue button when wallet is not connected', () => {
+      mockWalletState('idle', null);
+      render(<Connect />);
+
+      expect(screen.queryByRole('button', { name: /Continue to Dashboard/i })).toBeNull();
+    });
+
+    it('does not show Continue button when wallet is connecting', () => {
+      mockWalletState('connecting', null);
+      render(<Connect />);
+
+      expect(screen.queryByRole('button', { name: /Continue to Dashboard/i })).toBeNull();
+    });
+  });
+
+  describe('advanced address validation panel', () => {
+    it('reveals network selection and address input when advanced toggle is clicked', () => {
+      render(<Connect />);
+
+      const toggle = screen.getByRole('button', {
+        name: /Advanced: validate an address manually/i,
+      });
+      fireEvent.click(toggle);
+
+      // Network buttons should appear
+      expect(screen.getByRole('button', { name: 'Mainnet' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Testnet' })).toBeInTheDocument();
+
+      // Address input should appear
+      expect(screen.getByLabelText('Stellar Address')).toBeInTheDocument();
+
+      // Validate button should appear
+      expect(screen.getByRole('button', { name: 'Validate Address' })).toBeInTheDocument();
+    });
+
+    it('hides advanced panel content when toggle is clicked twice', () => {
+      render(<Connect />);
+
+      const toggle = screen.getByRole('button', {
+        name: /Advanced: validate an address manually/i,
+      });
+
+      // Open
+      fireEvent.click(toggle);
+      expect(screen.getByLabelText('Stellar Address')).toBeInTheDocument();
+
+      // Close
+      fireEvent.click(toggle);
+      expect(screen.queryByLabelText('Stellar Address')).toBeNull();
+    });
+
+    it('disables Validate Address button when address is invalid', () => {
+      render(<Connect />);
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /Advanced: validate an address manually/i }),
+      );
+
+      const validateBtn = screen.getByRole('button', { name: 'Validate Address' });
+      expect(validateBtn).toBeDisabled();
+    });
+  });
+
+  describe('no network calls', () => {
+    it('does not make real fetch calls', () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      render(<Connect />);
+      // The only fetch that could happen is from mocked hooks/components
+      // Verify no unmocked fetch was triggered
+      expect(fetchSpy).not.toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
+  });
+});

--- a/src/pages/Pools.test.tsx
+++ b/src/pages/Pools.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import Pools from './Pools';
+
+describe('Pools Page', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('rendering', () => {
+    it('renders the Liquidity Pools heading', async () => {
+      render(<Pools />);
+
+      // Fast-forward past the setTimeout in the useEffect
+      await act(async () => {
+        vi.advanceTimersByTime(800);
+      });
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Liquidity Pools');
+    });
+
+    it('renders the description subtitle', async () => {
+      render(<Pools />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(800);
+      });
+
+      expect(
+        screen.getByText(/Transparency and historical stats for all active round pools/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows a loading spinner initially', () => {
+      render(<Pools />);
+
+      // Before the timer fires, we should see a loading indicator
+      // The component renders a div with animate-spin class
+      const spinner = document.querySelector('.animate-spin');
+      expect(spinner).toBeInTheDocument();
+    });
+
+    it('hides the loading spinner after data loads', async () => {
+      render(<Pools />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(800);
+      });
+
+      const spinner = document.querySelector('.animate-spin');
+      expect(spinner).toBeNull();
+    });
+  });
+
+  describe('pool cards', () => {
+    it('renders pool cards for BTC, ETH, and XLM', async () => {
+      render(<Pools />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(800);
+      });
+
+      expect(screen.getByText('BTC Pool')).toBeInTheDocument();
+      expect(screen.getByText('ETH Pool')).toBeInTheDocument();
+      expect(screen.getByText('XLM Pool')).toBeInTheDocument();
+    });
+
+    it('displays total volume for each pool', async () => {
+      render(<Pools />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(800);
+      });
+
+      // Check that vXLM labels appear (volume currency)
+      const vxlmLabels = screen.getAllByText('vXLM');
+      expect(vxlmLabels.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('renders UP/DOWN pool sections', async () => {
+      render(<Pools />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(800);
+      });
+
+      const upDownHeaders = screen.getAllByText('UP/DOWN Pool');
+      expect(upDownHeaders).toHaveLength(3);
+    });
+
+    it('renders Precision Pool sections', async () => {
+      render(<Pools />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(800);
+      });
+
+      const precisionHeaders = screen.getAllByText('Precision Pool');
+      expect(precisionHeaders).toHaveLength(3);
+    });
+
+    it('renders Historical Yield sections', async () => {
+      render(<Pools />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(800);
+      });
+
+      const yieldHeaders = screen.getAllByText('Historical Yield');
+      expect(yieldHeaders).toHaveLength(3);
+    });
+  });
+
+  describe('loaded state', () => {
+    it('renders pool data after loading completes', async () => {
+      render(<Pools />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(800);
+      });
+
+      // Should render pools data for all three assets
+      expect(screen.getByText('BTC Pool')).toBeInTheDocument();
+      expect(screen.getByText('ETH Pool')).toBeInTheDocument();
+      expect(screen.getByText('XLM Pool')).toBeInTheDocument();
+    });
+  });
+
+  describe('no network calls', () => {
+    it('does not make real fetch calls', () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      render(<Pools />);
+
+      // Pools uses mock data with setTimeout, no fetch
+      expect(fetchSpy).not.toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
+  });
+});

--- a/src/pages/Profile.test.tsx
+++ b/src/pages/Profile.test.tsx
@@ -1,0 +1,220 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock useProfileStore
+const mockLoadProfile = vi.fn();
+const mockProfile = {
+  avatarUrl: null,
+  name: '',
+  bio: '',
+  twitterLink: '',
+  streamerMode: false,
+};
+
+vi.mock('../store/useProfileStore', () => ({
+  useProfileStore: vi.fn(),
+}));
+
+// Mock ProfileSettingsModal
+vi.mock('../components/ProfileSettingsModal', () => ({
+  default: ({ onClose, initialValues }: { onClose: () => void; initialValues: any }) => (
+    <div data-testid="profile-settings-modal" data-initial-name={initialValues?.name}>
+      <button data-testid="close-settings-modal" onClick={onClose}>
+        Close Modal
+      </button>
+    </div>
+  ),
+}));
+
+import Profile from './Profile';
+import { useProfileStore } from '../store/useProfileStore';
+
+const mockUseProfileStore = vi.mocked(useProfileStore);
+
+function mockStoreState(overrides: {
+  profile?: typeof mockProfile | null;
+  isLoading?: boolean;
+  error?: string | null;
+}) {
+  const state = {
+    profile: overrides.profile !== undefined ? overrides.profile : mockProfile,
+    isLoading: overrides.isLoading ?? false,
+    error: overrides.error ?? null,
+    loadProfile: mockLoadProfile,
+  };
+
+  mockUseProfileStore.mockImplementation((selector: any) => {
+    if (typeof selector === 'function') return selector(state);
+    return state;
+  });
+}
+
+describe('Profile Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStoreState({ isLoading: true, profile: null });
+  });
+
+  describe('rendering', () => {
+    it('renders the Profile heading', () => {
+      mockStoreState({});
+      render(<Profile />);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Profile');
+    });
+
+    it('renders the subtitle text', () => {
+      mockStoreState({});
+      render(<Profile />);
+
+      expect(
+        screen.getByText(/Manage the name, avatar, bio, and public link shown across Xelma/i),
+      ).toBeInTheDocument();
+    });
+
+    it('renders the Edit profile button', () => {
+      mockStoreState({});
+      render(<Profile />);
+
+      expect(screen.getByRole('button', { name: /Edit profile/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows loading spinner when isLoading is true and profile is null', () => {
+      mockStoreState({ isLoading: true, profile: null });
+      render(<Profile />);
+
+      expect(screen.getByText(/Loading profile/i)).toBeInTheDocument();
+    });
+
+    it('shows loading spinner while profile is loading and null', () => {
+      mockStoreState({ isLoading: true, profile: null });
+      render(<Profile />);
+
+      // The Edit profile button is in the page header, rendered before the
+      // conditional loading block, so it still appears.
+      expect(screen.getByRole('button', { name: /Edit profile/i })).toBeInTheDocument();
+      // But the main profile content (name/avatar) should show the loading spinner
+      expect(screen.getByText(/Loading profile/i)).toBeInTheDocument();
+      expect(screen.queryByText('Anonymous Player')).toBeNull();
+    });
+  });
+
+  describe('loaded state', () => {
+    it('renders profile content when loaded', () => {
+      mockStoreState({
+        profile: { avatarUrl: null, name: 'TestUser', bio: 'Test bio', twitterLink: '', streamerMode: false },
+        isLoading: false,
+      });
+      render(<Profile />);
+
+      expect(screen.getByText('TestUser')).toBeInTheDocument();
+      expect(screen.getByText('Test bio')).toBeInTheDocument();
+    });
+
+    it('shows "Anonymous Player" when no name is set', () => {
+      mockStoreState({
+        profile: { avatarUrl: null, name: '', bio: '', twitterLink: '', streamerMode: false },
+        isLoading: false,
+      });
+      render(<Profile />);
+
+      expect(screen.getByText('Anonymous Player')).toBeInTheDocument();
+    });
+
+    it('shows Streamer mode badge when streamerMode is enabled', () => {
+      mockStoreState({
+        profile: { avatarUrl: null, name: 'TestUser', bio: '', twitterLink: '', streamerMode: true },
+        isLoading: false,
+      });
+      render(<Profile />);
+
+      expect(screen.getByText('Streamer mode')).toBeInTheDocument();
+    });
+
+    it('shows prompt to personalize when no profile details exist', () => {
+      mockStoreState({
+        profile: { avatarUrl: null, name: '', bio: '', twitterLink: '', streamerMode: false },
+        isLoading: false,
+      });
+      render(<Profile />);
+
+      expect(screen.getByText(/Your profile is ready to personalize/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('error state', () => {
+    it('displays error message with retry button when error exists', () => {
+      mockStoreState({
+        profile: null,
+        isLoading: false,
+        error: 'Failed to load profile',
+      });
+      render(<Profile />);
+
+      expect(screen.getByText('Failed to load profile')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Retry/i })).toBeInTheDocument();
+    });
+
+    it('calls loadProfile on retry button click', () => {
+      mockStoreState({
+        profile: null,
+        isLoading: false,
+        error: 'Failed to load profile',
+      });
+      render(<Profile />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Retry/i }));
+      expect(mockLoadProfile).toHaveBeenCalled();
+    });
+  });
+
+  describe('settings modal', () => {
+    it('opens settings modal when Edit profile is clicked', () => {
+      mockStoreState({
+        profile: { avatarUrl: null, name: '', bio: '', twitterLink: '', streamerMode: false },
+        isLoading: false,
+      });
+      render(<Profile />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Edit profile/i }));
+
+      expect(screen.getByTestId('profile-settings-modal')).toBeInTheDocument();
+    });
+
+    it('closes settings modal when onClose is called', () => {
+      mockStoreState({
+        profile: { avatarUrl: null, name: '', bio: '', twitterLink: '', streamerMode: false },
+        isLoading: false,
+      });
+      render(<Profile />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Edit profile/i }));
+      expect(screen.getByTestId('profile-settings-modal')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('close-settings-modal'));
+      expect(screen.queryByTestId('profile-settings-modal')).toBeNull();
+    });
+  });
+
+  describe('initialization', () => {
+    it('calls loadProfile on mount', () => {
+      mockStoreState({});
+      render(<Profile />);
+
+      expect(mockLoadProfile).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('no network calls', () => {
+    it('does not make real fetch calls', () => {
+      mockStoreState({});
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      render(<Profile />);
+      // All data comes from mocked store, no real fetch should occur
+      expect(fetchSpy).not.toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Overview

This PR addresses two Stellar Wave good-first-issues:

- **Closes #338** — Document Stellar Wave contributor architecture in CONTRIBUTING.md
- **Closes #331** — Add unit tests for Connect, Profile, and Pools pages

---

## Changes — Issue #338: Contributor architecture documentation

**File:** CONTRIBUTING.md (+59 lines, -2 lines)

### Frontend architecture section updated:
- Clarified `/dashboard` is the single primary prediction terminal (it now includes price chart, round lifecycle timeline, connection status, end-round modal, and opt-in community chat)
- Documented that `/play` is **deprecated** and permanently redirects to `/dashboard`
- Noted that `LegacyDashboard` is retained for reference only and is no longer routed

### New "Stellar Wave contributor quick-start" section added with three subsections:

**1. Find rebuild stubs with `ContributorTaskPlaceholder`**
- Explains that `ContributorTaskPlaceholder` is a temporary shell marking UI surfaces stubbed for contributor rebuilds
- Provides a copy-pasteable `grep` command to find all stubs
- Includes a reference table of 9 currently stubbed components with their file locations

**2. How to claim a rebuild issue**
- 5-step workflow: browse labeled issues → comment to express interest → replace placeholder → remove import → open PR with `Closes #`

**3. Freighter + Soroban environment variables**
- Documented `VITE_STELLAR_RPC_URL`, `VITE_XELMA_CONTRACT_ID`, `VITE_STELLAR_NETWORK_PASSPHRASE`, and `VITE_STELLAR_NETWORK`
- Each entry includes whether it's required, defaults, and where it's consumed
- Freighter wallet installation link and connection architecture overview

---

## Changes — Issue #331: Page unit tests

Three new test files, **38 tests total, all passing** ✅

| Test File | Tests | What's Covered |
|---|---|---|
| `src/pages/Connect.test.tsx` (174 lines) | 12 | Heading, WalletConnect rendering, connected state, Continue to Dashboard CTA, advanced panel toggle, no network calls |
| `src/pages/Profile.test.tsx` (220 lines) | 15 | Heading, loading/loaded/error states, streamer mode badge, modal open/close, Edit profile CTA, initialization, no network calls |
| `src/pages/Pools.test.tsx` (146 lines) | 11 | Heading, loading spinner, pool cards for BTC/ETH/XLM, UP/DOWN & Precision pools, historical yield, no network calls |

### Mocking strategy:
- **Connect.test.tsx**: Mocks `useStellarAddressValidation`, `WalletConnect`, `useWalletStore`, `react-router-dom` (`useNavigate`), and `sonner` toast
- **Profile.test.tsx**: Mocks `useProfileStore` (with configurable loading/error/loaded states) and `ProfileSettingsModal`
- **Pools.test.tsx**: No external API mocks needed (component uses `setTimeout` + mock data); uses `vi.useFakeTimers()` for deterministic behavior

### Acceptance criteria met:
- ✅ Three new test files pass in `pnpm test:unit` (all 38 tests green)
- ✅ No network calls in unit tests — all data sources are mocked
- ✅ Primary headings and CTA presence verified for all three pages
- ✅ All tests follow existing project patterns (zustand store mocking, vitest + RTL)

---

## Pre-existing CI issues (not introduced by this PR)

The following build/lint failures exist on `main` and are **not caused by these changes**:
- `src/App.tsx` — unused `ENTER` variable
- `src/components/RoundCard.tsx` — unused `endTime` variable
- `src/components/RoundTimeline.tsx` — unused state variables + missing imports
- `src/pages/Dashboard.tsx` — undefined `balance`
- `src/components/education/GuideCard.tsx` & `TipCard.tsx` — incorrect relative import path for `ContributorTaskPlaceholder`

These should be addressed in a separate cleanup PR.

---

## Checklist

- [x] PR references issues (`Closes #338`, `Closes #331`)
- [x] PR focused on one concern (Stellar Wave contributor enablement)
- [x] `pnpm test:unit` passes for all new tests (38/38)
- [x] No new lint or typecheck errors introduced
- [x] No env vars, migrations, or manual QA steps required
- [x] No visual UI changes (docs + tests only)