### PR TITLE
feat: rebuild ModeCards with Directional and Precision cards linking to /dashboard

### DIFF
--- a/src/components/ModeCards.tsx
+++ b/src/components/ModeCards.tsx
@@ -1,21 +1,160 @@
-import ContributorTaskPlaceholder from './ContributorTaskPlaceholder';
+import { TrendingUp, Crosshair } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 /**
- * STUBBED for Stellar Wave hackathon — rebuild prediction mode cards.
- * Must link CTAs to `/dashboard` (and optionally coming-soon modes).
- * Visual language: glass-card, blue for UP/DOWN, teal for Precision.
+ * Mode selection cards shown on the Landing page.
+ *
+ * Displays two prediction modes:
+ * - **Directional (UP/DOWN)** — blue accent, binary price prediction
+ * - **Precision (Narrow Range)** — teal accent, tighter-window trading
+ *
+ * Both CTAs route to `/dashboard` where the prediction terminal lives.
  */
+const MODES = [
+  {
+    id: 'directional',
+    title: 'Directional Trading',
+    subtitle: 'UP / DOWN',
+    description:
+      'Predict whether an asset price will go up or down within a fixed time window.',
+    accent: 'blue' as const,
+    icon: TrendingUp,
+    bullets: [
+      'Binary price prediction',
+      'Real-time market data',
+      'Instant settlement',
+    ],
+  },
+  {
+    id: 'precision',
+    title: 'Precision Trading',
+    subtitle: 'Narrow Range',
+    description:
+      'Lock in tighter price windows for higher potential multipliers on each prediction.',
+    accent: 'teal' as const,
+    icon: Crosshair,
+    bullets: [
+      'Tighter price windows',
+      'Higher payout multipliers',
+      'Advanced strategy mode',
+    ],
+  },
+] as const;
+
+const ACCENT_STYLES = {
+  blue: {
+    borderGlow: 'border-xelma-blue/30 hover:border-xelma-blue/50',
+    glow: 'shadow-[0_0_24px_rgba(44,75,253,0.10)]',
+    badge: 'bg-xelma-blue/10 text-xelma-blue',
+    badgeBorder: 'border-xelma-blue/20',
+    iconBg: 'bg-xelma-blue/10 text-xelma-blue',
+    button:
+      'bg-xelma-blue text-white hover:bg-xelma-blue-dark focus-visible:ring-xelma-blue',
+    bulletDot: 'bg-xelma-blue',
+  },
+  teal: {
+    borderGlow: 'border-xelma-teal/30 hover:border-xelma-teal/50',
+    glow: 'shadow-[0_0_24px_rgba(6,182,212,0.10)]',
+    badge: 'bg-xelma-teal/10 text-xelma-teal',
+    badgeBorder: 'border-xelma-teal/20',
+    iconBg: 'bg-xelma-teal/10 text-xelma-teal',
+    button:
+      'bg-xelma-teal text-white hover:brightness-90 focus-visible:ring-xelma-teal',
+    bulletDot: 'bg-xelma-teal',
+  },
+} as const;
+
 export default function ModeCards() {
   return (
-    <section className="py-16 px-4 sm:px-6 lg:px-8" aria-labelledby="modes-title">
-      <h2 id="modes-title" className="text-center text-3xl font-bold text-white">
-        Two Prediction Modes
-      </h2>
-      <ContributorTaskPlaceholder
-        className="mx-auto mt-10 max-w-3xl"
-        title="Rebuild Mode Cards"
-        issueHint="Build UP/DOWN and Precision mode cards with feature bullets and CTAs to /dashboard. Match Landing fintech theme (glass-card, blue/teal accents)."
-      />
+    <section
+      className="px-4 py-16 sm:px-6 lg:px-8"
+      aria-labelledby="modes-title"
+    >
+      <div className="mx-auto max-w-5xl">
+        <h2
+          id="modes-title"
+          className="text-center text-3xl font-bold tracking-tight text-white"
+        >
+          Two Prediction Modes
+        </h2>
+        <p className="mx-auto mt-3 max-w-xl text-center text-gray-400">
+          Choose the trading style that fits your strategy. Both modes use
+          practice vXLM — no deposit required.
+        </p>
+
+        <div className="mt-10 grid gap-6 sm:grid-cols-2">
+          {MODES.map((mode) => {
+            const Icon = mode.icon;
+            const styles = ACCENT_STYLES[mode.accent];
+
+            return (
+              <article
+                key={mode.id}
+                className={`glass-card group relative flex flex-col rounded-2xl p-6 transition-all duration-300 sm:p-8 ${styles.borderGlow} ${styles.glow}`}
+              >
+                {/* Accent line at top */}
+                <div
+                  aria-hidden="true"
+                  className={`absolute -inset-x-px -top-px h-1 rounded-t-2xl bg-gradient-to-r ${
+                    mode.accent === 'blue'
+                      ? 'from-xelma-blue to-xelma-blue/60'
+                      : 'from-xelma-teal to-xelma-teal/60'
+                  }`}
+                />
+
+                {/* Header */}
+                <div className="flex items-start gap-4">
+                  <div
+                    className={`flex size-12 shrink-0 items-center justify-center rounded-xl ${styles.iconBg} transition-transform duration-300 group-hover:scale-110`}
+                  >
+                    <Icon className="size-6" aria-hidden="true" />
+                  </div>
+                  <div className="min-w-0">
+                    <h3 className="text-xl font-bold text-white">
+                      {mode.title}
+                    </h3>
+                    <span
+                      className={`mt-1 inline-block rounded-full border px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wider ${styles.badge} ${styles.badgeBorder}`}
+                    >
+                      {mode.subtitle}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Description */}
+                <p className="mt-4 text-sm leading-relaxed text-gray-400">
+                  {mode.description}
+                </p>
+
+                {/* Feature bullets */}
+                <ul className="mt-4 space-y-2">
+                  {mode.bullets.map((bullet) => (
+                    <li key={bullet} className="flex items-start gap-2.5">
+                      <span
+                        className={`mt-1.5 inline-block size-1.5 shrink-0 rounded-full ${styles.bulletDot}`}
+                        aria-hidden="true"
+                      />
+                      <span className="text-sm text-gray-300">{bullet}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                {/* Spacer */}
+                <div className="flex-1" />
+
+                {/* CTA */}
+                <Link
+                  to="/dashboard"
+                  className={`mt-6 inline-flex w-full items-center justify-center gap-2 rounded-xl px-5 py-3 text-sm font-bold transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-xelma-bg ${styles.button}`}
+                >
+                  Start Predicting
+                  <span aria-hidden="true">&rarr;</span>
+                </Link>
+              </article>
+            );
+          })}
+        </div>
+      </div>
     </section>
   );
 }

--- a/src/components/__tests__/ModeCards.test.tsx
+++ b/src/components/__tests__/ModeCards.test.tsx
@@ -1,0 +1,79 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import ModeCards from '../ModeCards';
+
+describe('ModeCards', () => {
+  const renderCards = () =>
+    render(
+      <MemoryRouter>
+        <ModeCards />
+      </MemoryRouter>,
+    );
+
+  it('renders the section title', () => {
+    renderCards();
+    expect(
+      screen.getByRole('heading', { name: /two prediction modes/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the Directional card with UP / DOWN subtitle', () => {
+    renderCards();
+    expect(
+      screen.getByRole('heading', { name: /directional trading/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('UP / DOWN'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the Precision card with Narrow Range subtitle', () => {
+    renderCards();
+    expect(
+      screen.getByRole('heading', { name: /precision trading/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Narrow Range'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders directional feature bullets', () => {
+    renderCards();
+    expect(screen.getByText(/binary price prediction/i)).toBeInTheDocument();
+    expect(screen.getByText(/real-time market data/i)).toBeInTheDocument();
+    expect(screen.getByText(/instant settlement/i)).toBeInTheDocument();
+  });
+
+  it('renders precision feature bullets', () => {
+    renderCards();
+    // "Tighter price windows" also appears in the description text, so it matches twice
+    const tighterPriceMatches = screen.getAllByText(/tighter price windows/i);
+    expect(tighterPriceMatches.length).toBeGreaterThanOrEqual(1);
+    expect(tighterPriceMatches[0]).toBeInTheDocument();
+
+    expect(screen.getByText(/higher payout multipliers/i)).toBeInTheDocument();
+    expect(screen.getByText(/advanced strategy mode/i)).toBeInTheDocument();
+  });
+
+  it('has both CTA links pointing to /dashboard', () => {
+    renderCards();
+    const links = screen.getAllByRole('link', { name: /start predicting/i });
+    expect(links).toHaveLength(2);
+    links.forEach((link) => {
+      expect(link).toHaveAttribute('href', '/dashboard');
+    });
+  });
+
+  it('renders accessible descriptions for both cards', () => {
+    renderCards();
+    // Each card article acts as a named region
+    expect(
+      screen.getByRole('heading', { name: /directional trading/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /precision trading/i }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
closes #285 
## Summary

Replaces the stubbed `ContributorTaskPlaceholder` in `ModeCards.tsx` with two fully built glass-style prediction mode cards that match the Landing page fintech design language.

## What changed

- **`src/components/ModeCards.tsx`** — Full rebuild with two `<article>` cards:
  - **Directional (UP/DOWN)** — blue accent (`xelma-blue`), `TrendingUp` icon, 3 feature bullets, CTA → `/dashboard`
  - **Precision (Narrow Range)** — teal accent (`xelma-teal`), `Crosshair` icon, 3 feature bullets, CTA → `/dashboard`
- **`src/components/__tests__/ModeCards.test.tsx`** — New test file (7 tests) covering titles, subtitles, feature bullets, CTA routing, and accessibility

## Key design decisions

- Used the existing `glass-card` CSS class from `index.css` to match Landing page visual identity
- Used custom `@theme` tokens (`xelma-blue`, `xelma-teal`, etc.) for brand-consistent colors — no new dependencies
- Responsive grid: `grid gap-6 sm:grid-cols-2` (stacks on mobile, side-by-side on sm+)
- Hover/focus: card border brightens, icon scales (`group-hover:scale-110`), buttons darken via `hover:brightness-90` and have `focus-visible:ring-2`
- Used `lucide-react` icons (`TrendingUp`, `Crosshair`) already installed in the project
- No separate CSS file — Tailwind utility classes only (project convention)

## Acceptance criteria checklist

- [x] Two cards: Directional (UP/DOWN) and Precision
- [x] CTAs link to `/dashboard`
- [x] Blue accent for directional, teal for precision
- [x] Feature bullets readable on mobile (responsive grid)
- [x] Hover/focus states present
- [x] Both cards navigate to `/dashboard`

## Test output

```
 ✓ src/components/__tests__/ModeCards.test.tsx (7 tests) 14ms
   ✓ renders the section title
   ✓ renders the Directional card with UP / DOWN subtitle
   ✓ renders the Precision card with Narrow Range subtitle
   ✓ renders directional feature bullets
   ✓ renders precision feature bullets
   ✓ has both CTA links pointing to /dashboard
   ✓ renders accessible descriptions for both cards
```

All ModeCards tests pass. TypeScript compiles clean (`tsc --noEmit`). Pre-existing test failures in `StatsCard`, `Dashboard` test files, and `Learn` test files are unrelated to this change (broken imports in education stubs).

## Honest follow-ups

- Add `aria-label` attributes to each `<article>` for improved screenreader navigation (acceptable as-is since internal `<h3>` headings are present)
- Consider adding `--color-xelma-teal-dark` to the theme for a convention-consistent dark hover state on the Precision button (currently uses `hover:brightness-90`)

## Security note

No auth, secrets, or user input involved. Pure presentational component with static content and internal route links.