### PR TITLE
feat: rebuild RoundTimer with SVG circular countdown and brand tokens

### DIFF
--- a/src/components/RoundTimer.tsx
+++ b/src/components/RoundTimer.tsx
@@ -1,21 +1,127 @@
-import ContributorTaskPlaceholder from './ContributorTaskPlaceholder';
+import { useState, useEffect } from 'react';
+import { useRoundCountdown } from '../hooks/useRoundCountdown';
 
 interface RoundTimerProps {
+  /** Target end time for the countdown. */
+  endTime: string | number | Date;
+  /** Label shown below the timer. */
   playersOnline?: number;
+  className?: string;
+}
+
+// SVG circle constants — circumference = 2 * π * r
+const RADIUS = 44;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS; // ≈ 276.46
+const VIEWBOX_SIZE = 120;
+
+/** Returns a hex colour keyed to how much time is left. */
+function getArcColour(timeLeftMs: number, isExpired: boolean): string {
+  if (isExpired) return '#6B7280';
+  if (timeLeftMs < 30_000) return '#EF4444'; // red — < 30 s
+  if (timeLeftMs < 120_000) return '#FBBF24'; // amber — < 2 min
+  return '#06B6D4'; // teal — > 2 min
 }
 
 /**
- * STUBBED for Stellar Wave hackathon — rebuild circular round timer.
- * Replace inline styles with Tailwind + brand tokens. Show countdown
- * and players-online label. Respect prefers-reduced-motion.
+ * Circular countdown timer with brand-token colours, SVG progress arc,
+ * and a "Playing now" players-online label.
+ *
+ * Dark-fintech theme. Respects `prefers-reduced-motion` via the global CSS
+ * rule that strips transitions when the user opts in.
  */
-const RoundTimer: React.FC<RoundTimerProps> = ({ playersOnline = 128 }) => {
-  return (
-    <ContributorTaskPlaceholder
-      title="Rebuild Round Timer"
-      issueHint={`Build a circular countdown timer with brand colors and "Playing now: ${playersOnline}". Avoid light-theme inline styles.`}
-    />
-  );
-};
+export default function RoundTimer({
+  endTime,
+  playersOnline = 128,
+  className = '',
+}: RoundTimerProps) {
+  const { formattedTime, isExpired, timeLeftMs } = useRoundCountdown(endTime);
 
-export default RoundTimer;
+  // Store the initial duration (in ms) once so we can compute the arc
+  // percentage. Computed synchronously so the arc is correct from the
+  // first paint — no flicker. Re‑computed only when `endTime` changes.
+  const resolveTimestamp = (t: string | number | Date): number => {
+    if (t instanceof Date) return t.getTime();
+    if (typeof t === 'string') return new Date(t).getTime();
+    return Number(t);
+  };
+
+  const [initialDurationMs, setInitialDurationMs] = useState(() => {
+    const diff = resolveTimestamp(endTime) - Date.now();
+    return diff > 0 ? diff : 1;
+  });
+
+  useEffect(() => {
+    const diff = resolveTimestamp(endTime) - Date.now();
+    setInitialDurationMs(diff > 0 ? diff : 1);
+  }, [endTime]);
+
+  const progress =
+    initialDurationMs > 0
+      ? Math.min(timeLeftMs / initialDurationMs, 1)
+      : 1;
+
+  const offset = CIRCUMFERENCE * (1 - progress);
+  const arcColour = getArcColour(timeLeftMs, isExpired);
+
+  return (
+    <div
+      className={`glass-card inline-flex flex-col items-center rounded-2xl p-5 sm:p-6 ${className}`}
+      role="timer"
+      aria-label={
+        isExpired
+          ? 'Round has ended'
+          : `Time remaining: ${formattedTime}`
+      }
+    >
+      {/* Circular countdown */}
+      <svg
+        viewBox={`0 0 ${VIEWBOX_SIZE} ${VIEWBOX_SIZE}`}
+        className="h-28 w-28 sm:h-32 sm:w-32"
+        aria-hidden="true"
+      >
+        {/* Track circle */}
+        <circle
+          cx={VIEWBOX_SIZE / 2}
+          cy={VIEWBOX_SIZE / 2}
+          r={RADIUS}
+          fill="none"
+          stroke="rgba(190,199,254,0.12)"
+          strokeWidth="5"
+        />
+
+        {/* Progress arc */}
+        <circle
+          cx={VIEWBOX_SIZE / 2}
+          cy={VIEWBOX_SIZE / 2}
+          r={RADIUS}
+          fill="none"
+          stroke={arcColour}
+          strokeWidth="5"
+          strokeLinecap="round"
+          strokeDasharray={CIRCUMFERENCE}
+          strokeDashoffset={offset}
+          transform={`rotate(-90 ${VIEWBOX_SIZE / 2} ${VIEWBOX_SIZE / 2})`}
+          style={{
+            transition: 'stroke-dashoffset 0.5s ease, stroke 0.3s ease',
+          }}
+        />
+
+        {/* Centre text */}
+        <text
+          x={VIEWBOX_SIZE / 2}
+          y={VIEWBOX_SIZE / 2}
+          textAnchor="middle"
+          dominantBaseline="central"
+          className="fill-white font-mono text-sm font-bold tabular-nums sm:text-base"
+        >
+          {isExpired ? 'ENDED' : formattedTime}
+        </text>
+      </svg>
+
+      {/* Players-online label */}
+      <p className="mt-2 text-xs font-medium text-gray-400 sm:text-sm">
+        Playing now: {playersOnline.toLocaleString()}
+      </p>
+    </div>
+  );
+}

--- a/src/components/__tests__/RoundTimer.test.tsx
+++ b/src/components/__tests__/RoundTimer.test.tsx
@@ -1,0 +1,123 @@
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import RoundTimer from '../RoundTimer';
+
+describe('RoundTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Pin system time so snapshots are deterministic.
+    vi.setSystemTime(new Date('2026-06-27T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  /** Helper: a Date `seconds` from the pinned system time. */
+  const inSeconds = (s: number) => new Date(Date.now() + s * 1000);
+
+  it('renders a timer with role="timer"', () => {
+    render(<RoundTimer endTime={inSeconds(120)} />);
+    expect(screen.getByRole('timer')).toBeInTheDocument();
+  });
+
+  it('displays the formatted countdown in the SVG text', () => {
+    render(<RoundTimer endTime={inSeconds(120)} />);
+    // 120 s = 02:00
+    expect(screen.getByText('02:00')).toBeInTheDocument();
+  });
+
+  it('counts down every second', () => {
+    render(<RoundTimer endTime={inSeconds(120)} />);
+    expect(screen.getByText('02:00')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByText('01:59')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(59_000);
+    });
+    expect(screen.getByText('01:00')).toBeInTheDocument();
+  });
+
+  it('shows ENDED when time expires', () => {
+    render(<RoundTimer endTime={inSeconds(2)} />);
+    expect(screen.queryByText('ENDED')).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(screen.getByText('ENDED')).toBeInTheDocument();
+  });
+
+  it('shows ENDED when endTime is in the past', () => {
+    render(<RoundTimer endTime={new Date(Date.now() - 5000)} />);
+    expect(screen.getByText('ENDED')).toBeInTheDocument();
+  });
+
+  it('renders the players-online label with default value', () => {
+    render(<RoundTimer endTime={inSeconds(120)} />);
+    expect(screen.getByText(/playing now: 128/i)).toBeInTheDocument();
+  });
+
+  it('renders a custom playersOnline value', () => {
+    render(<RoundTimer endTime={inSeconds(120)} playersOnline={42} />);
+    expect(screen.getByText(/playing now: 42/i)).toBeInTheDocument();
+  });
+
+  it('renders a large playersOnline value with locale formatting', () => {
+    render(<RoundTimer endTime={inSeconds(120)} playersOnline={1_500} />);
+    expect(screen.getByText(/playing now: 1[,]?500/i)).toBeInTheDocument();
+  });
+
+  it('updates aria-label as time passes', () => {
+    render(<RoundTimer endTime={inSeconds(120)} />);
+    const timer = screen.getByRole('timer');
+    expect(timer).toHaveAttribute('aria-label', 'Time remaining: 02:00');
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(timer).toHaveAttribute('aria-label', 'Time remaining: 01:00');
+  });
+
+  it('updates aria-label to ended state when expired', () => {
+    render(<RoundTimer endTime={inSeconds(2)} />);
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    const timer = screen.getByRole('timer');
+    expect(timer).toHaveAttribute('aria-label', 'Round has ended');
+  });
+
+  it('renders an SVG element with accessible hidden attribute', () => {
+    render(<RoundTimer endTime={inSeconds(120)} />);
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('applies custom className', () => {
+    render(
+      <RoundTimer endTime={inSeconds(120)} className="my-custom-class" />,
+    );
+    const timer = screen.getByRole('timer');
+    expect(timer.className).toMatch(/my-custom-class/);
+  });
+
+  it('cleans up intervals on unmount', () => {
+    const { unmount } = render(<RoundTimer endTime={inSeconds(120)} />);
+    unmount();
+    // No error should be thrown after unmount
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
closes #288 
## Summary

Replaces the stubbed `ContributorTaskPlaceholder` in `RoundTimer.tsx` with an SVG-based circular countdown timer using brand tokens and the dark fintech terminal theme.

## What changed

- **`src/components/RoundTimer.tsx`** — Full rebuild with:
  - SVG circular countdown (radius 44, viewBox 120x120)
  - Progress arc that shrinks as time runs out (`stroke-dashoffset` animation)
  - Colour-coded arc: teal (>2 min) → amber (<2 min) → red (<30s) → gray (expired)
  - Centre text showing remaining time in MM:SS or HH:MM:SS format (or "ENDED")
  - "Playing now: {playersOnline}" label below the timer
  - `glass-card` container matching project design language
  - Uses existing `useRoundCountdown` hook
  - Respects `prefers-reduced-motion` via global CSS
  - Responsive sizing: `h-28 w-28` on mobile, `h-32 w-32` on sm+
- **`src/components/__tests__/RoundTimer.test.tsx`** — New test file (13 tests)

## Key design decisions

- **Initial duration computed synchronously** in `useState` initializer — no flicker on first paint (code review flag fixed)
- **`resolveTimestamp`** duplicated from `useRoundCountdown` hook because the hook doesn't expose total duration — acceptable for now; could be refactored as a follow-up
- **Reduced motion** handled by the existing global CSS in `index.css` that strips all transitions when `prefers-reduced-motion: reduce` is active
- **Accessibility**: `role="timer"` with dynamic `aria-label`, SVG marked `aria-hidden`, centre text as real SVG `<text>` element

## Acceptance criteria

- [x] Matches dark fintech terminal theme
- [x] Timer counts down and expires cleanly
- [x] Mobile-friendly size (112px mobile → 128px desktop)
- [x] Circular countdown with brand tokens (Tailwind, no light gray inline CSS)
- [x] Shows players-online label from props
- [x] Respects reduced motion

## Test output

```
 ✓ src/components/__tests__/RoundTimer.test.tsx (13 tests)
   ✓ renders a timer with role="timer"
   ✓ displays the formatted countdown in the SVG text
   ✓ counts down every second
   ✓ shows ENDED when time expires
   ✓ shows ENDED when endTime is in the past
   ✓ renders the players-online label with default value
   ✓ renders a custom playersOnline value
   ✓ renders a large playersOnline value with locale formatting
   ✓ updates aria-label as time passes
   ✓ updates aria-label to ended state when expired
   ✓ renders an SVG element with accessible hidden attribute
   ✓ applies custom className
   ✓ cleans up intervals on unmount
```

TypeScript compiles clean. Pre-existing failures in `StatsCard`, `Dashboard`, and `Learn` tests are unrelated.

## Honest follow-ups

- Add `totalDuration`/`initialTimeLeft` return value to `useRoundCountdown` hook to avoid duplicating timestamp resolution logic
- Wire `RoundTimer` into the Dashboard or landing page as a live round indicator (currently exported but not imported anywhere)

## Security note

No auth, secrets, or user input. Pure presentational component.
