### PR TITLE
feat: add command palette, Freighter E2E mocks, remove dead next-themes dependency

### DIFF
--- a/e2e/wallet-connect.spec.ts
+++ b/e2e/wallet-connect.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '@playwright/test';
+
+const MOCK_ADDRESS = 'GBHExampleAddressForTestingPurposesOnly1234567890ABCDE';
+
+/** Inject a fake Freighter wallet object before any app code runs. */
+function mockFreighter(page: import('@playwright/test').Page) {
+  return page.addInitScript(() => {
+    (window as unknown as Record<string, unknown>).freighter = {
+      isConnected: () => Promise.resolve({ isConnected: true }),
+      requestAccess: () =>
+        Promise.resolve({ address: 'GBHExampleAddressForTestingPurposesOnly1234567890ABCDE', error: null }),
+      getAddress: () =>
+        Promise.resolve({ address: 'GBHExampleAddressForTestingPurposesOnly1234567890ABCDE', error: null }),
+      getNetwork: () => Promise.resolve({ network: 'TESTNET', error: null }),
+      signMessage: (message: string) =>
+        Promise.resolve({ signedMessage: `mocked_signature_${message}`, error: null }),
+    };
+  });
+}
+
+test.describe('Wallet Connect – Freighter Mocked', () => {
+  test('Connect page shows wallet prompt and Connect Wallet button', async ({ page }) => {
+    await mockFreighter(page);
+
+    // Mock Horizon balance request
+    await page.route('**/horizon-testnet.stellar.org/accounts/**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          balances: [{ asset_type: 'native', balance: '100.00' }],
+        }),
+      }),
+    );
+
+    // Mock backend auth endpoints
+    await page.route('**/api/auth/**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ challenge: 'mock_challenge', token: 'mock_jwt_token' }),
+      }),
+    );
+
+    await page.goto('/connect');
+
+    // The Connect page renders the WalletConnect component
+    const connectButton = page.getByRole('button', { name: /connect wallet/i });
+    await expect(connectButton).toBeVisible();
+  });
+
+  test('Dashboard shows wallet prompt when not connected, then connects via Freighter', async ({ page }) => {
+    await mockFreighter(page);
+
+    // Mock Horizon balance request
+    await page.route('**/horizon-testnet.stellar.org/accounts/**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          balances: [{ asset_type: 'native', balance: '100.00' }],
+        }),
+      }),
+    );
+
+    // Mock backend auth endpoints
+    await page.route('**/api/auth/**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ challenge: 'mock_challenge', token: 'mock_jwt_token' }),
+      }),
+    );
+
+    await page.goto('/dashboard');
+
+    // Should show wallet prompt when not connected
+    const walletPrompt = page.locator('[data-testid="dashboard-wallet-prompt"]');
+    await expect(walletPrompt).toBeVisible();
+    await expect(walletPrompt).toContainText('Connect your wallet');
+
+    // Click "Connect now" which navigates to /connect
+    const connectNow = page.locator('[data-testid="dashboard-connect-now"]');
+    await expect(connectNow).toBeVisible();
+    await connectNow.click();
+
+    // Should navigate to /connect
+    await expect(page).toHaveURL(/\/connect/);
+
+    // Click "Connect Wallet" button to initiate Freighter flow
+    const connectButton = page.getByRole('button', { name: /connect wallet/i });
+    await expect(connectButton).toBeVisible();
+    await connectButton.click();
+
+    // After connection, the "Continue to Dashboard" button should appear
+    const continueBtn = page.getByRole('button', { name: /continue to dashboard/i });
+    await expect(continueBtn).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "clsx": "^2.1.1",
         "lightweight-charts": "^5.1.0",
         "lucide-react": "^0.563.0",
-        "next-themes": "^0.4.6",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.12.0",
@@ -2330,6 +2329,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",
@@ -5406,16 +5469,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/next-themes": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
-      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
-      }
     },
     "node_modules/node-releases": {
       "version": "2.0.27",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "clsx": "^2.1.1",
     "lightweight-charts": "^5.1.0",
     "lucide-react": "^0.563.0",
-    "next-themes": "^0.4.6",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.12.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react';
 import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { Toaster } from 'sonner';
 import Navbar from './components/Navbar';
+import CommandPalette from './components/CommandPalette';
 import PageSkeleton from './components/PageSkeleton';
 import Landing from './pages/Landing';
 import RouteFallback from './components/RouteFallback';
@@ -36,6 +37,7 @@ function App() {
       </a>
       <OfflineBanner />
       <Navbar />
+      <CommandPalette />
       <ErrorBoundary>
         <LazyBoundary>
           <Suspense fallback={<RouteFallback />}>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,219 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Search, LayoutDashboard, Trophy, BookOpen, Wallet, User, Droplets } from 'lucide-react';
+import clsx from 'clsx';
+import { useFocusTrap } from '../hooks/useFocusTrap';
+
+interface RouteItem {
+  label: string;
+  to: string;
+  icon: React.ComponentType<{ className?: string }>;
+}
+
+const routes: RouteItem[] = [
+  { label: 'Dashboard', to: '/dashboard', icon: LayoutDashboard },
+  { label: 'Leaderboard', to: '/leaderboard', icon: Trophy },
+  { label: 'Learn', to: '/learn', icon: BookOpen },
+  { label: 'Connect', to: '/connect', icon: Wallet },
+  { label: 'Profile', to: '/profile', icon: User },
+  { label: 'Pools', to: '/pools', icon: Droplets },
+];
+
+const focusRing =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0F1A]';
+
+export default function CommandPalette() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const filtered = routes.filter((r) =>
+    r.label.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setQuery('');
+    setSelectedIndex(0);
+  }, []);
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+    setQuery('');
+    setSelectedIndex(0);
+  }, []);
+
+  useFocusTrap(dialogRef, {
+    active: isOpen,
+    onEscape: close,
+  });
+
+  // Global Cmd/Ctrl+K listener
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        if (isOpen) {
+          close();
+        } else {
+          open();
+        }
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isOpen, open, close]);
+
+  // Reset selected index when filtered list changes
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    if (!isOpen) return;
+    const items = listRef.current?.querySelectorAll('[role="option"]');
+    items?.[selectedIndex]?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex, isOpen]);
+
+  // Focus input when opened
+  useEffect(() => {
+    if (isOpen) {
+      window.setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [isOpen]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedIndex((i) => (i + 1) % filtered.length);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedIndex((i) => (i - 1 + filtered.length) % filtered.length);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (filtered[selectedIndex]) {
+        navigate(filtered[selectedIndex].to);
+        close();
+      }
+    }
+  };
+
+  const handleSelect = (to: string) => {
+    navigate(to);
+    close();
+  };
+
+  return (
+    <>
+      {/* Modal overlay */}
+      {isOpen && (
+        <div className="fixed inset-0 z-[200] flex items-start justify-center pt-[15vh]">
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={close}
+            aria-hidden="true"
+          />
+
+          {/* Palette */}
+          <div
+            ref={dialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Command palette"
+            className={clsx(
+              'relative w-full max-w-md rounded-xl border border-[#BEC7FE]/15 bg-[#111827] shadow-2xl',
+              'animate-in fade-in zoom-in-95 duration-150',
+            )}
+          >
+            {/* Search input */}
+            <div className="flex items-center gap-3 border-b border-white/10 px-4 py-3">
+              <Search className="w-5 h-5 text-gray-500 shrink-0" aria-hidden />
+              <input
+                ref={inputRef}
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Jump to…"
+                className="flex-1 bg-transparent text-sm text-white placeholder-gray-500 outline-none"
+                role="combobox"
+                aria-expanded={isOpen}
+                aria-controls="command-palette-listbox"
+                aria-activedescendant={
+                  filtered[selectedIndex] ? `command-palette-option-${selectedIndex}` : undefined
+                }
+              />
+              <kbd className="hidden sm:inline-block rounded border border-white/10 bg-white/5 px-1.5 py-0.5 text-[10px] font-medium text-gray-500">
+                ESC
+              </kbd>
+            </div>
+
+            {/* Route list */}
+            <div
+              id="command-palette-listbox"
+              ref={listRef}
+              role="listbox"
+              aria-label="Routes"
+              className="max-h-64 overflow-y-auto p-1.5"
+            >
+              {filtered.length === 0 && (
+                <p className="px-4 py-6 text-center text-sm text-gray-500">
+                  No routes match "{query}"
+                </p>
+              )}
+              {filtered.map((route, index) => {
+                const Icon = route.icon;
+                const isSelected = index === selectedIndex;
+                const isCurrent = location.pathname === route.to;
+                return (
+                  <button
+                    key={route.to}
+                    id={`command-palette-option-${index}`}
+                    type="button"
+                    role="option"
+                    aria-selected={isSelected}
+                    onClick={() => handleSelect(route.to)}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                    className={clsx(
+                      'flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm transition-colors',
+                      isSelected
+                        ? 'bg-[#2C4BFD]/20 text-white'
+                        : 'text-gray-400 hover:bg-white/5 hover:text-white',
+                      isCurrent && 'ring-1 ring-[#2C4BFD]/30',
+                      focusRing,
+                    )}
+                  >
+                    <Icon className={clsx('w-4 h-4 shrink-0', isSelected ? 'text-[#BEC7FE]' : 'text-gray-500')} aria-hidden />
+                    <span className="flex-1 font-medium">{route.label}</span>
+                    {isCurrent && (
+                      <span className="rounded-full bg-[#2C4BFD]/20 px-2 py-0.5 text-[10px] font-semibold text-[#BEC7FE]">
+                        current
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Footer hint */}
+            <div className="flex items-center justify-between border-t border-white/10 px-4 py-2">
+              <span className="text-[10px] text-gray-500">
+                <kbd className="rounded border border-white/10 bg-white/5 px-1 py-0.5 text-[10px]">↑↓</kbd> navigate
+                {' '}
+                <kbd className="rounded border border-white/10 bg-white/5 px-1 py-0.5 text-[10px]">↵</kbd> select
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,7 +5,7 @@
 
 import { Link, useLocation } from 'react-router-dom';
 import { useEffect, useState, useRef, useCallback } from 'react';
-import { Menu, X } from 'lucide-react';
+import { Menu, X, Search } from 'lucide-react';
 import { useWalletStore, selectIsWalletConnected } from '../store/useWalletStore';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import Logo from '../assets/logo.svg';
@@ -144,6 +144,17 @@ export default function Navbar() {
           {/* Desktop Wallet & Mobile Menu Toggle */}
           <div className="flex items-center gap-3">
             <div className="hidden items-center gap-3 md:flex">
+              <button
+                type="button"
+                onClick={() => {
+                  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true }));
+                }}
+                className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-gray-400 hover:border-[#2C4BFD]/40 hover:text-white transition-colors"
+                aria-label="Open command palette (Ctrl+K)"
+              >
+                <Search className="w-4 h-4" />
+                <span className="text-xs">Ctrl+K</span>
+              </button>
               <NetworkBadge />
               {isConnected && publicKey ? (
                 <>


### PR DESCRIPTION
## Summary

- **Closes #339** — Removed unused `next-themes` dependency from `package.json` and updated the lockfile. The app uses a hardcoded dark theme via Tailwind classes; no ThemeProvider/ThemeContext ever existed.
- **Closes #334** — Added `e2e/wallet-connect.spec.ts` with a Freighter-mocked wallet connect flow using `page.addInitScript()` to inject a fake `window.freighter` object. Tests cover the Connect page button visibility and the full Dashboard→Connect→Freighter→Continue flow. No real browser extension required.
- **Closes #327** — Added `CommandPalette.tsx` component with Cmd/Ctrl+K shortcut, fuzzy route filtering, Arrow key + Enter navigation, focus trap, Escape close, and current-route indicator. Integrated into `App.tsx` and wired a trigger button in `Navbar.tsx`.

## Changes

| File | Change |
|---|---|
| `package.json` | Remove `next-themes` dependency |
| `package-lock.json` | Regenerated lockfile |
| `src/components/CommandPalette.tsx` | **New** — command palette component |
| `src/components/Navbar.tsx` | Add Ctrl+K trigger button |
| `src/App.tsx` | Mount `CommandPalette` in app shell |
| `e2e/wallet-connect.spec.ts` | **New** — Freighter-mocked Playwright spec |