### PR TITLE
feat: add formatRelativeTime utility and adopt in ChatSidebar + PredictionHistory

### DIFF
--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -3,6 +3,7 @@ import { MessageCircle } from "lucide-react";
 import { socketService } from "../lib/socket";
 import { useConnectionStatus } from "../hooks/useConnectionStatus";
 import { useRoundStore, selectActiveChatChannelId } from "../store/useRoundStore";
+import { formatRelativeTime } from "../lib/utils";
 import EmptyState from "./EmptyState";
 import { MODAL_OVERLAY, TRANSITION, TRANSFORM_TRANSITION } from "../utils/motion";
 
@@ -32,17 +33,6 @@ function mapApiMessage(msg: ApiMessage): Message {
     content: msg.content,
     timestamp: new Date(msg.createdAt),
   };
-}
-
-function formatTimestamp(date: Date): string {
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / (1000 * 60));
-
-  if (diffMins < 1) return "Just now";
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffMins < 1440) return `${Math.floor(diffMins / 60)}h ago`;
-  return date.toLocaleDateString();
 }
 
 function getInitials(username: string): string {
@@ -340,7 +330,7 @@ export function ChatSidebar({ showNewsRibbon = true }: ChatSidebarProps) {
                     {message.username}
                   </span>
                   <span className="font-['DM_Sans'] font-normal text-xs text-[#9B9B9B] dark:text-gray-400">
-                    {formatTimestamp(message.timestamp)}
+                    {formatRelativeTime(message.timestamp)}
                   </span>
                 </div>
                 <p className="font-['DM_Sans'] font-normal text-sm text-[#4D4D4D] dark:text-gray-300 text-wrap wrap-break-word">

--- a/src/components/PredictionHistory.tsx
+++ b/src/components/PredictionHistory.tsx
@@ -2,17 +2,10 @@ import { useCallback, useEffect, useState } from "react";
 import { predictionsApi, type UserPrediction } from "../lib/api-client";
 import { LoadingState, ErrorState, EmptyState } from "./ui/StatusStates";
 import { PanelHeader } from "./ui/PanelHeader";
-import { formatVXLM } from "../lib/utils";
+import { formatVXLM, formatRelativeTime } from "../lib/utils";
 
 interface PredictionHistoryProps {
   userId: string | null;
-}
-
-function formatDate(value?: string): string {
-  if (!value) return "Unknown time";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "Unknown time";
-  return date.toLocaleString();
 }
 
 function formatStake(value?: string | number): string {
@@ -126,7 +119,13 @@ export default function PredictionHistory({ userId }: PredictionHistoryProps) {
                     • Stake: {formatStake(prediction.stake)}
                   </p>
                   <p className="text-xs text-gray-500 dark:text-gray-400">
-                    {formatDate(typeof prediction.createdAt === "string" ? prediction.createdAt : undefined)}
+                    {(() => {
+  const raw = prediction.createdAt;
+  if (typeof raw !== "string") return "Unknown time";
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) return "Unknown time";
+  return formatRelativeTime(date);
+})()}
                   </p>
                 </div>
 

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { formatVXLM, formatPercent, formatCompactNumber } from '../utils';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { formatVXLM, formatPercent, formatCompactNumber, formatRelativeTime } from '../utils';
 
 describe('formatVXLM', () => {
   it('formats values below 1 000 with two decimal places', () => {
@@ -80,5 +80,55 @@ describe('formatCompactNumber', () => {
   it('handles non-finite values gracefully', () => {
     expect(formatCompactNumber(NaN)).toBe('0');
     expect(formatCompactNumber(Infinity)).toBe('0');
+  });
+});
+
+describe('formatRelativeTime', () => {
+  const now = new Date('2026-07-28T12:00:00Z');
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns "just now" for dates less than 60 seconds ago', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const date = new Date(now.getTime() - 30 * 1000);
+    expect(formatRelativeTime(date)).toBe('just now');
+  });
+
+  it('returns "just now" for future dates', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const date = new Date(now.getTime() + 5000);
+    expect(formatRelativeTime(date)).toBe('just now');
+  });
+
+  it('returns "Xm ago" for dates minutes ago', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    expect(formatRelativeTime(new Date(now.getTime() - 5 * 60 * 1000))).toBe('5m ago');
+    expect(formatRelativeTime(new Date(now.getTime() - 59 * 60 * 1000))).toBe('59m ago');
+  });
+
+  it('returns "Xh ago" for dates hours ago', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    expect(formatRelativeTime(new Date(now.getTime() - 3 * 60 * 60 * 1000))).toBe('3h ago');
+    expect(formatRelativeTime(new Date(now.getTime() - 23 * 60 * 60 * 1000))).toBe('23h ago');
+  });
+
+  it('returns "Xd ago" for dates days ago', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    expect(formatRelativeTime(new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000))).toBe('5d ago');
+    expect(formatRelativeTime(new Date(now.getTime() - 29 * 24 * 60 * 60 * 1000))).toBe('29d ago');
+  });
+
+  it('falls back to toLocaleDateString for dates older than 30 days', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const date = new Date(now.getTime() - 31 * 24 * 60 * 60 * 1000);
+    expect(formatRelativeTime(date)).toBe(date.toLocaleDateString());
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -49,3 +49,25 @@ export function formatCompactNumber(value: number, decimals = 2): string {
   }
   return `${sign}${abs.toFixed(decimals)}`;
 }
+
+/**
+ * Format a date as a relative time string (e.g. "just now", "5m ago", "3h ago", "2d ago").
+ * Falls back to toLocaleDateString for dates older than 30 days.
+ */
+export function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+
+  if (diffMs < 0) return "just now";
+
+  const diffSecs = Math.floor(diffMs / 1000);
+  const diffMins = Math.floor(diffSecs / 60);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffSecs < 60) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 30) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}


### PR DESCRIPTION
Extract the inline relative-time formatting logic into a shared formatRelativeTime() utility in src/lib/utils.ts that returns consistent human-readable timestamps ("just now", "5m ago", "3h ago", "2d ago") with a 30-day fallback to toLocaleDateString(). Replace the local formatTimestamp in ChatSidebar and the absolute formatDate in PredictionHistory with the new utility, making timestamps uniform across the app. Includes unit tests for seconds, minutes, hours, days, future dates, and the 30-day boundary.

Closes #336