### PR TITLE
feat: add stellar terminal empty illustrations

### DIFF
--- a/src/assets/no-history.svg
+++ b/src/assets/no-history.svg
@@ -1,0 +1,8 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="20" y="18" width="56" height="64" rx="8" stroke="#2C4BFD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="#2C4BFD" fill-opacity="0.08"/>
+  <line x1="32" y1="36" x2="64" y2="36" stroke="#2C4BFD" stroke-width="2" stroke-linecap="round" stroke-opacity="0.3"/>
+  <line x1="32" y1="46" x2="58" y2="46" stroke="#06B6D4" stroke-width="2" stroke-linecap="round" stroke-opacity="0.2"/>
+  <line x1="32" y1="56" x2="52" y2="56" stroke="#6366F1" stroke-width="2" stroke-linecap="round" stroke-opacity="0.15"/>
+  <path d="M62 62 L65 68 L72 68 L67 72 L68 80 L62 75 L56 80 L57 72 L52 68 L59 68 Z" fill="#22D3EE" fill-opacity="0.4"/>
+  <circle cx="62" cy="70" r="2" fill="#22D3EE" opacity="0.8"/>
+</svg>

--- a/src/assets/no-rounds.svg
+++ b/src/assets/no-rounds.svg
@@ -1,0 +1,8 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <ellipse cx="48" cy="48" rx="38" ry="14" stroke="#2C4BFD" stroke-width="2" stroke-linecap="round" stroke-opacity="0.25" transform="rotate(-20 48 48)"/>
+  <ellipse cx="48" cy="48" rx="28" ry="10" stroke="#06B6D4" stroke-width="2" stroke-linecap="round" stroke-dasharray="4 6" stroke-opacity="0.2" transform="rotate(15 48 48)"/>
+  <circle cx="78" cy="36" r="3" fill="#22D3EE" opacity="0.7"/>
+  <path d="M48 18 L51 42 L74 46 L50 49 L47 72 L44 49 L20 46 L45 42 Z" stroke="#2C4BFD" stroke-width="2.5" stroke-linejoin="round" fill="#2C4BFD" fill-opacity="0.15"/>
+  <path d="M48 26 L50 43 L66 45 L49 47 L47 62 L45 47 L28 45 L46 43 Z" fill="#06B6D4" fill-opacity="0.3"/>
+  <circle cx="48" cy="45" r="4" fill="#22D3EE"/>
+</svg>

--- a/src/assets/offline.svg
+++ b/src/assets/offline.svg
@@ -1,0 +1,10 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M28 28 L40 36 L28 44" stroke="#2C4BFD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.3"/>
+  <path d="M68 28 L56 36 L68 44" stroke="#2C4BFD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.3"/>
+  <polyline points="48 66 48 54 40 46" stroke="#2C4BFD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.25"/>
+  <line x1="42" y1="60" x2="56" y2="46" stroke="#EF4444" stroke-width="2" stroke-linecap="round" stroke-dasharray="3 3" stroke-opacity="0.5"/>
+  <circle cx="28" cy="36" r="4" fill="#2C4BFD" fill-opacity="0.4"/>
+  <circle cx="68" cy="36" r="4" fill="#2C4BFD" fill-opacity="0.4"/>
+  <circle cx="48" cy="66" r="4" fill="#6366F1" fill-opacity="0.4"/>
+  <circle cx="40" cy="46" r="3" fill="#06B6D4" fill-opacity="0.3"/>
+</svg>

--- a/src/components/NotificationsPanel.tsx
+++ b/src/components/NotificationsPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { useNotificationsStore } from '../store/useNotificationsStore';
-import { Clock, Check } from './icons';
+import { Check } from './icons';
 import { LoadingState, ErrorState, EmptyState } from './ui/StatusStates';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 
@@ -91,7 +91,7 @@ const NotificationsPanel: React.FC<{ id: string; onClose: () => void }> = ({
         )}
         {!loadingList && !errorList && list.length === 0 && (
           <EmptyState
-            icon={<Clock className="h-12 w-12 text-gray-300 dark:text-gray-700 mb-4" />}
+            variant="offline"
             title="No notifications"
             message="You're all caught up! New notifications will appear here."
             className="p-4"

--- a/src/components/PredictionHistory.tsx
+++ b/src/components/PredictionHistory.tsx
@@ -53,6 +53,7 @@ export default function PredictionHistory({ userId }: PredictionHistoryProps) {
           title="Connect your wallet"
           message="Connect your wallet to view your prediction history."
           className="min-h-[200px]"
+          variant="no-history"
         />
       </section>
     );
@@ -88,6 +89,7 @@ export default function PredictionHistory({ userId }: PredictionHistoryProps) {
           title="No predictions yet"
           message="Start making predictions to see your history here."
           className="min-h-[200px]"
+          variant="no-history"
         />
       )}
 

--- a/src/components/icons/StellarIllustrations.tsx
+++ b/src/components/icons/StellarIllustrations.tsx
@@ -1,0 +1,39 @@
+interface IllustrationProps {
+  className?: string;
+  size?: number;
+}
+
+export const NoRoundsIllustration = ({ className, size = 96 }: IllustrationProps) => (
+  <svg width={size} height={size} viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg" className={className} aria-hidden="true">
+    <ellipse cx="48" cy="48" rx="38" ry="14" stroke="#2C4BFD" strokeWidth="2" strokeLinecap="round" strokeOpacity="0.25" transform="rotate(-20 48 48)" />
+    <ellipse cx="48" cy="48" rx="28" ry="10" stroke="#06B6D4" strokeWidth="2" strokeLinecap="round" strokeDasharray="4 6" strokeOpacity="0.2" transform="rotate(15 48 48)" />
+    <circle cx="78" cy="36" r="3" fill="#22D3EE" opacity="0.7" />
+    <path d="M48 18 L51 42 L74 46 L50 49 L47 72 L44 49 L20 46 L45 42 Z" stroke="#2C4BFD" strokeWidth="2.5" strokeLinejoin="round" fill="#2C4BFD" fillOpacity="0.15" />
+    <path d="M48 26 L50 43 L66 45 L49 47 L47 62 L45 47 L28 45 L46 43 Z" fill="#06B6D4" fillOpacity="0.3" />
+    <circle cx="48" cy="45" r="4" fill="#22D3EE" />
+  </svg>
+);
+
+export const NoHistoryIllustration = ({ className, size = 96 }: IllustrationProps) => (
+  <svg width={size} height={size} viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg" className={className} aria-hidden="true">
+    <rect x="20" y="18" width="56" height="64" rx="8" stroke="#2C4BFD" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="#2C4BFD" fillOpacity="0.08" />
+    <line x1="32" y1="36" x2="64" y2="36" stroke="#2C4BFD" strokeWidth="2" strokeLinecap="round" strokeOpacity="0.3" />
+    <line x1="32" y1="46" x2="58" y2="46" stroke="#06B6D4" strokeWidth="2" strokeLinecap="round" strokeOpacity="0.2" />
+    <line x1="32" y1="56" x2="52" y2="56" stroke="#6366F1" strokeWidth="2" strokeLinecap="round" strokeOpacity="0.15" />
+    <path d="M62 62 L65 68 L72 68 L67 72 L68 80 L62 75 L56 80 L57 72 L52 68 L59 68 Z" fill="#22D3EE" fillOpacity="0.4" />
+    <circle cx="62" cy="70" r="2" fill="#22D3EE" opacity="0.8" />
+  </svg>
+);
+
+export const OfflineIllustration = ({ className, size = 96 }: IllustrationProps) => (
+  <svg width={size} height={size} viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg" className={className} aria-hidden="true">
+    <path d="M28 28 L40 36 L28 44" stroke="#2C4BFD" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" strokeOpacity="0.3" />
+    <path d="M68 28 L56 36 L68 44" stroke="#2C4BFD" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" strokeOpacity="0.3" />
+    <polyline points="48 66 48 54 40 46" stroke="#2C4BFD" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" strokeOpacity="0.25" />
+    <line x1="42" y1="60" x2="56" y2="46" stroke="#EF4444" strokeWidth="2" strokeLinecap="round" strokeDasharray="3 3" strokeOpacity="0.5" />
+    <circle cx="28" cy="36" r="4" fill="#2C4BFD" fillOpacity="0.4" />
+    <circle cx="68" cy="36" r="4" fill="#2C4BFD" fillOpacity="0.4" />
+    <circle cx="48" cy="66" r="4" fill="#6366F1" fillOpacity="0.4" />
+    <circle cx="40" cy="46" r="3" fill="#06B6D4" fillOpacity="0.3" />
+  </svg>
+);

--- a/src/components/ui/StatusStates.tsx
+++ b/src/components/ui/StatusStates.tsx
@@ -1,5 +1,10 @@
 import { Loader2, AlertCircle, Inbox, RefreshCw } from "lucide-react";
 import { cn } from "../../lib/utils";
+import {
+  NoRoundsIllustration,
+  NoHistoryIllustration,
+  OfflineIllustration,
+} from "../icons/StellarIllustrations";
 
 interface LoadingProps {
     message?: string;
@@ -66,17 +71,35 @@ export const ErrorState = ({ message, onRetry, className, title = "Oops! Somethi
     );
 };
 
+const variantIllustrations = {
+  "no-rounds": NoRoundsIllustration,
+  "no-history": NoHistoryIllustration,
+  offline: OfflineIllustration,
+} as const;
+
+type EmptyVariant = keyof typeof variantIllustrations;
+
 interface EmptyProps {
     title: string;
     message: string;
     icon?: React.ReactNode;
     className?: string;
+    variant?: EmptyVariant;
 }
 
-export const EmptyState = ({ title, message, icon, className }: EmptyProps) => (
-    <div className={cn("flex flex-col items-center justify-center p-12 text-center rounded-2xl border border-dashed border-white/10 bg-[#111827]/40 backdrop-blur-sm min-h-[200px]", className)}>
-        {icon || <Inbox className="h-12 w-12 text-gray-500 mb-4" />}
-        <h3 className="text-xl font-bold text-white mb-2">{title}</h3>
-        <p className="text-gray-400 max-w-sm text-sm">{message}</p>
-    </div>
-);
+export const EmptyState = ({ title, message, icon, className, variant }: EmptyProps) => {
+    const Illustration = variant ? variantIllustrations[variant] : null;
+    const iconElement = icon ?? (
+      Illustration
+        ? <Illustration className="mb-4" />
+        : <Inbox className="h-12 w-12 text-gray-500 mb-4" />
+    );
+
+    return (
+        <div className={cn("flex flex-col items-center justify-center p-12 text-center rounded-2xl border border-dashed border-white/10 bg-[#111827]/40 backdrop-blur-sm min-h-[200px]", className)}>
+            {iconElement}
+            <h3 className="text-xl font-bold text-white mb-2">{title}</h3>
+            <p className="text-gray-400 max-w-sm text-sm">{message}</p>
+        </div>
+    );
+};

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -19,6 +19,7 @@ import { Link } from "react-router-dom";
 import { TipCard } from "../components/education/TipCard";
 import type { Tip } from "../types/education";
 import EmptyState from '../components/EmptyState';
+import { NoRoundsIllustration } from '../components/icons/StellarIllustrations';
 import DashboardSkeleton from '../components/DashboardSkeleton';
 import { mockUserStats } from "../data/mockData";
 import type { RecentActivityItem } from "../types";
@@ -337,6 +338,7 @@ const Dashboard = () => {
           <EmptyState
             title="No Active Rounds"
             description="Learn how the game works or refresh to check for new rounds."
+            icon={<NoRoundsIllustration className="mb-4" />}
             action={
               <button
                 type="button"


### PR DESCRIPTION
## Add Stellar-themed empty illustrations for terminal panels

Adds a shared set of 3 Stellar-themed SVG empty state illustrations for terminal panels (`no-rounds`, `no-history`, `offline`) and integrates them across the Dashboard, PredictionHistory, and NotificationsPanel.

### Changes

**New assets & components**
- `src/assets/no-rounds.svg` — star with orbital rings
- `src/assets/no-history.svg` — document with star marker
- `src/assets/offline.svg` — constellation with broken connection
- `src/components/icons/StellarIllustrations.tsx` — React wrappers for the SVGs (`className`, `size` props)

**Updated panels (3 total)**
- `src/components/ui/StatusStates.tsx` — `EmptyState` accepts a `variant` prop (`"no-rounds" | "no-history" | "offline"`) mapping to the corresponding illustration
- `src/pages/Dashboard.tsx` — "No Active Rounds" shows `NoRoundsIllustration`
- `src/components/PredictionHistory.tsx` — "No predictions yet" / "Connect your wallet" use `variant="no-history"`
- `src/components/NotificationsPanel.tsx` — "No notifications" uses `variant="offline"`; removed unused `Clock` import

### Design
- Consistent stroke style (`stroke-linecap="round"`, `stroke-linejoin="round"`) matching brand
- Brand colors: `#2C4BFD` (Xelma Blue), `#06B6D4` (Teal), `#22D3EE` (Bright Teal), `#6366F1` (Indigo)
- All illustrations have `aria-hidden="true"` by default


Closes #317 