### PR TITLE
feat: Horizon balances viewer, XDR preview drawer, multi-wallet picker, and on-chain event log

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,10 @@ VITE_API_BASE_URL=http://localhost:3000
 
 
 # Stellar network to display in the app badge. Set to PUBLIC for mainnet.
+# Also selects the default Horizon endpoint and the StellarExpert explorer network.
 VITE_STELLAR_NETWORK=TESTNET
+
+# Horizon endpoint used for account balances and trustlines.
+# Optional — defaults to horizon-testnet.stellar.org, or horizon.stellar.org when
+# VITE_STELLAR_NETWORK is PUBLIC/MAINNET. Set this only to override that default.
+# VITE_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org

--- a/README.md
+++ b/README.md
@@ -105,9 +105,10 @@ bundle.
 | --------------------------------- | -------- | ----------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------- |
 | `VITE_API_BASE_URL`               | ✅ yes   | `src/lib/config.ts`           | `http://localhost:3000`                                   | Root URL of the Xelma backend (REST + Socket.IO origin).                |
 | `VITE_API_URL`                    | ⚠️ legacy| `src/lib/config.ts` (fallback)| —                                                         | **Deprecated** — kept as a fallback for `VITE_API_BASE_URL`. New deploys should use `VITE_API_BASE_URL`. |
-| `VITE_STELLAR_NETWORK`            | optional | `src/components/Navbar.tsx`   | `TESTNET`                                                 | Human-readable network label (`TESTNET`, `PUBLIC`, or `MAINNET`). Drives the navbar badge. |
+| `VITE_STELLAR_NETWORK`            | optional | `src/components/Navbar.tsx`, `src/lib/horizon.ts` | `TESTNET`                              | Network label (`TESTNET`, `PUBLIC`, or `MAINNET`). Drives the navbar badge, the default Horizon endpoint, and the StellarExpert explorer network. |
 | `VITE_STELLAR_NETWORK_PASSPHRASE` | ✅ prod  | `src/lib/xelma-contract.ts`, `src/components/Footer.tsx` | `Test SDF Network ; September 2015` (Networks.TESTNET) | Network passphrase used to build/sign Soroban transactions. Use `Public Global Stellar Network ; September 2015` for mainnet. |
-| `VITE_STELLAR_RPC_URL`            | ✅ prod  | `src/lib/xelma-contract.ts`   | `https://soroban-testnet.stellar.org`                     | Soroban JSON-RPC endpoint used to simulate/submit/polling.              |
+| `VITE_STELLAR_RPC_URL`            | ✅ prod  | `src/lib/xelma-contract.ts`, `src/lib/prediction-events.ts` | `https://soroban-testnet.stellar.org`   | Soroban JSON-RPC endpoint used to simulate/submit/poll transactions and to read contract events. |
+| `VITE_STELLAR_HORIZON_URL`        | optional | `src/lib/horizon.ts`          | Derived from `VITE_STELLAR_NETWORK`                       | Horizon endpoint for account balances and trustlines. Defaults to `horizon-testnet.stellar.org`, or `horizon.stellar.org` on `PUBLIC`/`MAINNET`. Set only to override. |
 | `VITE_XELMA_CONTRACT_ID`          | ✅ prod  | `src/lib/xelma-contract.ts`   | Testnet placeholder contract id                           | Deployed Xelma Soroban contract id (`C…`) for the target network.       |
 
 ### `.env` examples

--- a/src/components/BalancesPanel.test.tsx
+++ b/src/components/BalancesPanel.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import BalancesPanel from './BalancesPanel';
+import { useWalletStore } from '../store/useWalletStore';
+
+const ADDRESS = 'GCEXAMPLE7ADDRESS7FOR7TESTS7ONLY7AAAAAAAAAAAAAAAAAAAAAAAA';
+
+function setConnected(publicKey: string | null) {
+  useWalletStore.setState({
+    status: publicKey ? 'connected' : 'idle',
+    publicKey,
+  });
+}
+
+function mockHorizon(value: unknown) {
+  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(value);
+}
+
+describe('BalancesPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useWalletStore.getState().reset();
+  });
+
+  it('renders nothing when the wallet is not connected', () => {
+    setConnected(null);
+    const { container } = render(<BalancesPanel />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows a loading state while balances are in flight', () => {
+    setConnected(ADDRESS);
+    (global.fetch as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+
+    render(<BalancesPanel />);
+
+    expect(screen.getByLabelText('Loading balances')).toBeInTheDocument();
+  });
+
+  it('renders the native balance and each trustline once loaded', async () => {
+    setConnected(ADDRESS);
+    mockHorizon({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        balances: [
+          { asset_type: 'native', balance: '250.0000000' },
+          { asset_type: 'credit_alphanum4', asset_code: 'USDC', asset_issuer: 'GISSUER', balance: '40.5000000' },
+        ],
+      }),
+    });
+
+    render(<BalancesPanel />);
+
+    expect(await screen.findByText('250.00')).toBeInTheDocument();
+    expect(screen.getByText('USDC')).toBeInTheDocument();
+    expect(screen.getByText('40.50')).toBeInTheDocument();
+  });
+
+  it('shows an empty trustlines message when the account holds only XLM', async () => {
+    setConnected(ADDRESS);
+    mockHorizon({
+      ok: true,
+      status: 200,
+      json: async () => ({ balances: [{ asset_type: 'native', balance: '10.0000000' }] }),
+    });
+
+    render(<BalancesPanel />);
+
+    expect(await screen.findByText(/no trustlines yet/i)).toBeInTheDocument();
+  });
+
+  it('shows an unfunded empty state when Horizon returns 404', async () => {
+    setConnected(ADDRESS);
+    mockHorizon({ ok: false, status: 404, json: async () => ({}) });
+
+    render(<BalancesPanel />);
+
+    expect(await screen.findByText(/account not funded/i)).toBeInTheDocument();
+  });
+
+  it('shows an error state with a retry button when the fetch fails', async () => {
+    setConnected(ADDRESS);
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('offline'));
+
+    render(<BalancesPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/could not load balances/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/BalancesPanel.tsx
+++ b/src/components/BalancesPanel.tsx
@@ -1,0 +1,211 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Coins, ExternalLink, RefreshCw, AlertCircle } from 'lucide-react';
+import {
+  fetchAccountBalances,
+  formatBalance,
+  HORIZON_URL,
+  type AccountBalances,
+} from '../lib/horizon';
+import { accountUrl } from '../lib/explorer';
+import { useWalletStore } from '../store/useWalletStore';
+
+type LoadState = 'idle' | 'loading' | 'loaded' | 'error';
+
+function TrustlineRow({
+  code,
+  balance,
+  issuer,
+  isAuthorized,
+}: {
+  code: string;
+  balance: string;
+  issuer: string | null;
+  isAuthorized: boolean;
+}) {
+  return (
+    <li className="flex items-center justify-between gap-3 py-2">
+      <div className="min-w-0">
+        <p className="truncate text-sm font-semibold text-white">
+          {code}
+          {!isAuthorized && (
+            <span className="ml-2 rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-bold uppercase text-amber-400">
+              Unauthorized
+            </span>
+          )}
+        </p>
+        {issuer && (
+          <p className="truncate font-mono text-[11px] text-gray-500">
+            {issuer.slice(0, 4)}…{issuer.slice(-4)}
+          </p>
+        )}
+      </div>
+      <span className="shrink-0 font-mono text-sm text-gray-300">{formatBalance(balance)}</span>
+    </li>
+  );
+}
+
+/**
+ * Compact Horizon balances viewer for the connected wallet.
+ *
+ * Shows the native XLM balance plus every trustline on the account, reading the
+ * Horizon endpoint from env so the panel follows the configured network.
+ */
+export default function BalancesPanel({ className }: { className?: string }) {
+  const publicKey = useWalletStore((s) => s.publicKey);
+  const status = useWalletStore((s) => s.status);
+  const isConnected = status === 'connected' && Boolean(publicKey);
+
+  const [data, setData] = useState<AccountBalances | null>(null);
+  const [state, setState] = useState<LoadState>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const refresh = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  useEffect(() => {
+    if (!publicKey || !isConnected) {
+      setData(null);
+      setState('idle');
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const run = async () => {
+      setState('loading');
+      setError(null);
+      try {
+        const result = await fetchAccountBalances(publicKey, controller.signal);
+        if (controller.signal.aborted) return;
+        setData(result);
+        setState('loaded');
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : 'Could not load balances.');
+        setState('error');
+      }
+    };
+
+    void run();
+
+    return () => controller.abort();
+  }, [publicKey, isConnected, reloadKey]);
+
+  if (!isConnected) return null;
+
+  const hasTrustlines = (data?.trustlines.length ?? 0) > 0;
+
+  return (
+    <section
+      className={`glass-card rounded-xl border border-white/10 p-4 ${className ?? ''}`}
+      aria-labelledby="balances-panel-heading"
+    >
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Coins className="h-4 w-4 text-[#22D3EE]" aria-hidden />
+          <h3 id="balances-panel-heading" className="text-sm font-bold text-white">
+            Balances
+          </h3>
+        </div>
+        <div className="flex items-center gap-1">
+          {publicKey && (
+            <a
+              href={accountUrl(publicKey)}
+              target="_blank"
+              rel="noreferrer"
+              className="rounded p-1.5 text-gray-500 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD]"
+              aria-label="View account on StellarExpert"
+            >
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+            </a>
+          )}
+          <button
+            type="button"
+            onClick={refresh}
+            disabled={state === 'loading'}
+            className="rounded p-1.5 text-gray-500 transition-colors hover:text-white disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD]"
+            aria-label="Refresh balances"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${state === 'loading' ? 'animate-spin' : ''}`} aria-hidden />
+          </button>
+        </div>
+      </div>
+
+      {state === 'loading' && (
+        <div className="space-y-2 py-1" aria-busy="true" aria-label="Loading balances">
+          <div className="h-8 w-2/3 animate-pulse rounded bg-white/5" />
+          <div className="h-4 w-1/2 animate-pulse rounded bg-white/5" />
+          <div className="h-4 w-5/12 animate-pulse rounded bg-white/5" />
+        </div>
+      )}
+
+      {state === 'error' && (
+        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-3" role="alert">
+          <div className="flex items-start gap-2">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" aria-hidden />
+            <div className="min-w-0">
+              <p className="text-xs font-semibold text-red-400">Could not load balances</p>
+              <p className="mt-1 break-words text-xs text-red-300/80">{error}</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={refresh}
+            className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-red-400/30 px-3 py-1.5 text-xs font-bold text-red-100 transition-colors hover:bg-red-400/10"
+          >
+            <RefreshCw className="h-3 w-3" aria-hidden />
+            Retry
+          </button>
+        </div>
+      )}
+
+      {state === 'loaded' && data?.isUnfunded && (
+        <div className="rounded-lg border border-dashed border-white/10 bg-white/[0.02] p-4 text-center">
+          <p className="text-sm font-semibold text-gray-300">Account not funded</p>
+          <p className="mt-1 text-xs text-gray-500">
+            This address does not exist on the network yet. Fund it to see balances.
+          </p>
+        </div>
+      )}
+
+      {state === 'loaded' && data && !data.isUnfunded && (
+        <>
+          <div className="flex items-baseline justify-between gap-3 border-b border-white/5 pb-3">
+            <span className="text-xs font-bold uppercase tracking-wider text-gray-500">XLM</span>
+            <span className="font-mono text-lg font-bold text-white">
+              {data.native ? formatBalance(data.native.balance) : '0.00'}
+            </span>
+          </div>
+
+          <div className="mt-3">
+            <p className="mb-1 text-xs font-bold uppercase tracking-wider text-gray-500">
+              Trustlines
+            </p>
+            {hasTrustlines ? (
+              <ul className="divide-y divide-white/5">
+                {data.trustlines.map((line) => (
+                  <TrustlineRow
+                    key={`${line.code}-${line.issuer ?? 'none'}`}
+                    code={line.code}
+                    balance={line.balance}
+                    issuer={line.issuer}
+                    isAuthorized={line.isAuthorized}
+                  />
+                ))}
+              </ul>
+            ) : (
+              <p className="py-2 text-xs text-gray-500">
+                No trustlines yet. Only XLM is held on this account.
+              </p>
+            )}
+          </div>
+        </>
+      )}
+
+      <p className="mt-3 truncate border-t border-white/5 pt-2 text-[10px] text-gray-600">
+        via {HORIZON_URL.replace(/^https?:\/\//, '')}
+      </p>
+    </section>
+  );
+}

--- a/src/components/BalancesPanel.tsx
+++ b/src/components/BalancesPanel.tsx
@@ -55,6 +55,8 @@ export default function BalancesPanel({ className }: { className?: string }) {
   const status = useWalletStore((s) => s.status);
   const isConnected = status === 'connected' && Boolean(publicKey);
 
+  /** Address the loaded balances belong to, so a wallet switch never shows stale numbers. */
+  const [loadedFor, setLoadedFor] = useState<string | null>(null);
   const [data, setData] = useState<AccountBalances | null>(null);
   const [state, setState] = useState<LoadState>('idle');
   const [error, setError] = useState<string | null>(null);
@@ -63,12 +65,7 @@ export default function BalancesPanel({ className }: { className?: string }) {
   const refresh = useCallback(() => setReloadKey((k) => k + 1), []);
 
   useEffect(() => {
-    if (!publicKey || !isConnected) {
-      setData(null);
-      setState('idle');
-      setError(null);
-      return;
-    }
+    if (!publicKey || !isConnected) return;
 
     const controller = new AbortController();
 
@@ -79,6 +76,7 @@ export default function BalancesPanel({ className }: { className?: string }) {
         const result = await fetchAccountBalances(publicKey, controller.signal);
         if (controller.signal.aborted) return;
         setData(result);
+        setLoadedFor(publicKey);
         setState('loaded');
       } catch (err) {
         if (controller.signal.aborted) return;
@@ -94,7 +92,11 @@ export default function BalancesPanel({ className }: { className?: string }) {
 
   if (!isConnected) return null;
 
-  const hasTrustlines = (data?.trustlines.length ?? 0) > 0;
+  // Treat data fetched for a different address as not yet loaded.
+  const isFresh = loadedFor === publicKey;
+  const balances = isFresh ? data : null;
+  const viewState: LoadState = state === 'loaded' && !isFresh ? 'loading' : state;
+  const hasTrustlines = (balances?.trustlines.length ?? 0) > 0;
 
   return (
     <section
@@ -123,16 +125,16 @@ export default function BalancesPanel({ className }: { className?: string }) {
           <button
             type="button"
             onClick={refresh}
-            disabled={state === 'loading'}
+            disabled={viewState === 'loading'}
             className="rounded p-1.5 text-gray-500 transition-colors hover:text-white disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD]"
             aria-label="Refresh balances"
           >
-            <RefreshCw className={`h-3.5 w-3.5 ${state === 'loading' ? 'animate-spin' : ''}`} aria-hidden />
+            <RefreshCw className={`h-3.5 w-3.5 ${viewState === 'loading' ? 'animate-spin' : ''}`} aria-hidden />
           </button>
         </div>
       </div>
 
-      {state === 'loading' && (
+      {viewState === 'loading' && (
         <div className="space-y-2 py-1" aria-busy="true" aria-label="Loading balances">
           <div className="h-8 w-2/3 animate-pulse rounded bg-white/5" />
           <div className="h-4 w-1/2 animate-pulse rounded bg-white/5" />
@@ -140,7 +142,7 @@ export default function BalancesPanel({ className }: { className?: string }) {
         </div>
       )}
 
-      {state === 'error' && (
+      {viewState === 'error' && (
         <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-3" role="alert">
           <div className="flex items-start gap-2">
             <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" aria-hidden />
@@ -160,7 +162,7 @@ export default function BalancesPanel({ className }: { className?: string }) {
         </div>
       )}
 
-      {state === 'loaded' && data?.isUnfunded && (
+      {viewState === 'loaded' && balances?.isUnfunded && (
         <div className="rounded-lg border border-dashed border-white/10 bg-white/[0.02] p-4 text-center">
           <p className="text-sm font-semibold text-gray-300">Account not funded</p>
           <p className="mt-1 text-xs text-gray-500">
@@ -169,12 +171,12 @@ export default function BalancesPanel({ className }: { className?: string }) {
         </div>
       )}
 
-      {state === 'loaded' && data && !data.isUnfunded && (
+      {viewState === 'loaded' && balances && !balances.isUnfunded && (
         <>
           <div className="flex items-baseline justify-between gap-3 border-b border-white/5 pb-3">
             <span className="text-xs font-bold uppercase tracking-wider text-gray-500">XLM</span>
             <span className="font-mono text-lg font-bold text-white">
-              {data.native ? formatBalance(data.native.balance) : '0.00'}
+              {balances.native ? formatBalance(balances.native.balance) : '0.00'}
             </span>
           </div>
 
@@ -184,7 +186,7 @@ export default function BalancesPanel({ className }: { className?: string }) {
             </p>
             {hasTrustlines ? (
               <ul className="divide-y divide-white/5">
-                {data.trustlines.map((line) => (
+                {balances.trustlines.map((line) => (
                   <TrustlineRow
                     key={`${line.code}-${line.issuer ?? 'none'}`}
                     code={line.code}

--- a/src/components/BetModal.tsx
+++ b/src/components/BetModal.tsx
@@ -3,6 +3,8 @@ import { useWalletStore, selectIsWalletConnected } from '../store/useWalletStore
 import { useAuthStore } from '../store/useAuthStore';
 import { place_bet, place_precision_prediction, estimatePlaceBet, estimatePrecisionPrediction, type FeeEstimate } from '../lib/xelma-contract';
 import { predictionsApi } from '../lib/api-client';
+import XdrPreviewDrawer from './XdrPreviewDrawer';
+import { txUrl } from '../lib/explorer';
 import { MODAL_OVERLAY, MODAL_CONTENT } from '../utils/motion';
 
 export interface PredictionData {
@@ -471,6 +473,14 @@ export default function BetModal({ isOpen, onClose, predictionData, onSuccess }:
               )}
             </div>
 
+            {feeEstimateStatus === 'loaded' && feeEstimate && (
+              <XdrPreviewDrawer
+                xdr={feeEstimate.xdr}
+                hash={feeEstimate.hash}
+                networkPassphrase={feeEstimate.networkPassphrase}
+              />
+            )}
+
             <button
               onClick={handleConfirm}
               disabled={!isConnected || feeEstimateStatus === 'failed'}
@@ -507,7 +517,7 @@ export default function BetModal({ isOpen, onClose, predictionData, onSuccess }:
             </p>
             <div className="space-y-3">
               <a
-                href={`https://stellarexpert.org/tx/${txHash}`}
+                href={txUrl(txHash)}
                 target="_blank"
                 rel="noreferrer"
                 className="block w-full py-3 bg-gray-800 hover:bg-gray-700 rounded-xl font-semibold transition"

--- a/src/components/EventLogDrawer.test.tsx
+++ b/src/components/EventLogDrawer.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import EventLogDrawer from './EventLogDrawer';
+import { fetchPredictionEvents, type PredictionEvent } from '../lib/prediction-events';
+
+vi.mock('../lib/prediction-events', async () => {
+  const actual = await vi.importActual<typeof import('../lib/prediction-events')>(
+    '../lib/prediction-events',
+  );
+  return { ...actual, fetchPredictionEvents: vi.fn() };
+});
+
+const fetchMock = vi.mocked(fetchPredictionEvents);
+
+function event(overrides: Partial<PredictionEvent> = {}): PredictionEvent {
+  return {
+    id: 'evt-1',
+    name: 'settle',
+    kind: 'settlement',
+    roundId: '7',
+    ledger: 1234,
+    timestamp: '2026-07-30T10:00:00Z',
+    txHash: 'txhash1',
+    payload: { winner: 'UP' },
+    ...overrides,
+  };
+}
+
+describe('EventLogDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when closed and does not fetch', () => {
+    const { container } = render(<EventLogDrawer isOpen={false} onClose={vi.fn()} />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('shows a loading state while events are in flight', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}));
+
+    render(<EventLogDrawer isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByLabelText('Loading on-chain events')).toBeInTheDocument();
+  });
+
+  it('lists loaded events with round and ledger detail', async () => {
+    fetchMock.mockResolvedValue([event()]);
+
+    render(<EventLogDrawer isOpen onClose={vi.fn()} />);
+
+    expect(await screen.findByText('settle')).toBeInTheDocument();
+    expect(screen.getByText(/round 7/i)).toBeInTheDocument();
+    expect(screen.getByText(/1,234/)).toBeInTheDocument();
+  });
+
+  it('links out to the explorer when a tx hash is present', async () => {
+    fetchMock.mockResolvedValue([event()]);
+
+    render(<EventLogDrawer isOpen onClose={vi.fn()} />);
+
+    const link = await screen.findByRole('link', { name: /view transaction/i });
+    expect(link).toHaveAttribute('href', expect.stringContaining('txhash1'));
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('omits the explorer link when an event has no tx hash', async () => {
+    fetchMock.mockResolvedValue([event({ txHash: null })]);
+
+    render(<EventLogDrawer isOpen onClose={vi.fn()} />);
+
+    await screen.findByText('settle');
+    expect(screen.queryByRole('link', { name: /view transaction/i })).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state when the contract has no events', async () => {
+    fetchMock.mockResolvedValue([]);
+
+    render(<EventLogDrawer isOpen onClose={vi.fn()} />);
+
+    expect(await screen.findByText(/no events yet/i)).toBeInTheDocument();
+  });
+
+  it('filters the list by round id', async () => {
+    fetchMock.mockResolvedValue([
+      event({ id: 'a', roundId: '7' }),
+      event({ id: 'b', roundId: '8', name: 'settle_other' }),
+    ]);
+
+    render(<EventLogDrawer isOpen onClose={vi.fn()} />);
+
+    await screen.findByText('settle');
+    fireEvent.change(screen.getByLabelText(/filter by round id/i), { target: { value: '8' } });
+
+    expect(screen.getByText('settle_other')).toBeInTheDocument();
+    expect(screen.queryByText('settle')).not.toBeInTheDocument();
+  });
+
+  it('shows a distinct empty state when the round filter matches nothing', async () => {
+    fetchMock.mockResolvedValue([event()]);
+
+    render(<EventLogDrawer isOpen onClose={vi.fn()} />);
+
+    await screen.findByText('settle');
+    fireEvent.change(screen.getByLabelText(/filter by round id/i), { target: { value: '999' } });
+
+    expect(screen.getByText(/no events for that round/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /clear filter/i })).toBeInTheDocument();
+  });
+
+  it('shows an error state with a retry button when the fetch fails', async () => {
+    fetchMock.mockRejectedValue(new Error('rpc down'));
+
+    render(<EventLogDrawer isOpen onClose={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByText(/could not load events/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it('closes on Escape and via the close button', async () => {
+    fetchMock.mockResolvedValue([]);
+    const onClose = vi.fn();
+
+    render(<EventLogDrawer isOpen onClose={onClose} />);
+    await screen.findByText(/no events yet/i);
+
+    fireEvent.click(screen.getByRole('button', { name: /close event log/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/EventLogDrawer.tsx
+++ b/src/components/EventLogDrawer.tsx
@@ -1,0 +1,275 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AlertCircle, ExternalLink, Radio, RefreshCw, X } from 'lucide-react';
+import {
+  fetchPredictionEvents,
+  filterByRound,
+  type PredictionEvent,
+  type PredictionEventKind,
+} from '../lib/prediction-events';
+import { txUrl } from '../lib/explorer';
+import { useFocusTrap } from '../hooks/useFocusTrap';
+import { MODAL_OVERLAY, PANEL_SLIDE_RIGHT } from '../utils/motion';
+
+interface EventLogDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+type LoadState = 'idle' | 'loading' | 'loaded' | 'error';
+
+const KIND_STYLES: Record<PredictionEventKind, string> = {
+  settlement: 'border-green-500/40 bg-green-500/10 text-green-400',
+  prediction: 'border-cyan-500/40 bg-cyan-500/10 text-cyan-300',
+  round: 'border-[#2C4BFD]/40 bg-[#2C4BFD]/10 text-[#BEC7FE]',
+  other: 'border-white/10 bg-white/5 text-gray-400',
+};
+
+function formatTimestamp(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString();
+}
+
+function formatPayload(payload: unknown): string | null {
+  if (payload === null || payload === undefined) return null;
+  try {
+    return JSON.stringify(
+      payload,
+      (_key, value) => (typeof value === 'bigint' ? value.toString() : value),
+      0,
+    );
+  } catch {
+    return null;
+  }
+}
+
+function EventRow({ event }: { event: PredictionEvent }) {
+  const payload = formatPayload(event.payload);
+
+  return (
+    <li className="rounded-xl border border-gray-800 bg-gray-950/70 p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="truncate font-mono text-sm font-bold text-white">{event.name}</span>
+            <span
+              className={`rounded border px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide ${KIND_STYLES[event.kind]}`}
+            >
+              {event.kind}
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-gray-500">
+            {event.roundId ? `Round ${event.roundId} · ` : ''}
+            Ledger {event.ledger.toLocaleString()} · {formatTimestamp(event.timestamp)}
+          </p>
+        </div>
+
+        {event.txHash && (
+          <a
+            href={txUrl(event.txHash)}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex shrink-0 items-center gap-1 rounded-lg border border-gray-700 px-2 py-1 text-[11px] font-semibold text-gray-300 transition-colors hover:border-gray-600 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD]"
+            aria-label={`View transaction ${event.txHash.slice(0, 8)} on StellarExpert`}
+          >
+            Explorer
+            <ExternalLink className="h-3 w-3" aria-hidden />
+          </a>
+        )}
+      </div>
+
+      {payload && (
+        <pre className="mt-2 max-h-20 overflow-auto rounded-lg bg-black/40 p-2 text-[11px]">
+          <code className="break-all whitespace-pre-wrap font-mono text-gray-400">{payload}</code>
+        </pre>
+      )}
+    </li>
+  );
+}
+
+/**
+ * Slide-over drawer listing recent on-chain prediction and settlement events,
+ * with a round-id filter and explorer links for events that carry a tx hash.
+ */
+export default function EventLogDrawer({ isOpen, onClose }: EventLogDrawerProps) {
+  const [events, setEvents] = useState<PredictionEvent[]>([]);
+  const [state, setState] = useState<LoadState>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [roundFilter, setRoundFilter] = useState('');
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useFocusTrap(drawerRef, {
+    active: isOpen,
+    onEscape: onClose,
+    initialFocusRef: closeButtonRef,
+  });
+
+  const refresh = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    let cancelled = false;
+
+    const run = async () => {
+      setState('loading');
+      setError(null);
+      try {
+        const result = await fetchPredictionEvents();
+        if (cancelled) return;
+        setEvents(result);
+        setState('loaded');
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Could not load events.');
+        setState('error');
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, reloadKey]);
+
+  const visible = useMemo(() => filterByRound(events, roundFilter), [events, roundFilter]);
+
+  if (!isOpen) return null;
+
+  const isFiltered = roundFilter.trim().length > 0;
+
+  return (
+    <div className="fixed inset-0 z-[70] flex">
+      <div
+        className={`absolute inset-0 bg-black/60 backdrop-blur-sm ${MODAL_OVERLAY}`}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      <div
+        ref={drawerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="event-log-title"
+        className={`relative ml-auto flex h-full w-full max-w-md flex-col border-l border-[#BEC7FE]/10 bg-[#0A0F1A] shadow-2xl ${PANEL_SLIDE_RIGHT}`}
+      >
+        <div className="flex items-start justify-between gap-3 border-b border-white/5 p-5">
+          <div>
+            <h2 id="event-log-title" className="flex items-center gap-2 text-lg font-bold text-white">
+              <Radio className="h-4 w-4 text-[#22D3EE]" aria-hidden />
+              On-chain events
+            </h2>
+            <p className="mt-1 text-xs text-gray-500">
+              Recent prediction and settlement events from the Xelma contract.
+            </p>
+          </div>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 text-gray-400 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD]"
+            aria-label="Close event log"
+          >
+            <X className="h-4 w-4" aria-hidden />
+          </button>
+        </div>
+
+        <div className="flex items-end gap-2 border-b border-white/5 p-4">
+          <div className="flex-1">
+            <label htmlFor="event-round-filter" className="mb-1 block text-xs font-semibold text-gray-400">
+              Filter by round id
+            </label>
+            <input
+              id="event-round-filter"
+              type="text"
+              inputMode="numeric"
+              value={roundFilter}
+              onChange={(e) => setRoundFilter(e.target.value)}
+              placeholder="All rounds"
+              className="w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white outline-none transition focus:border-[#2C4BFD]"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={refresh}
+            disabled={state === 'loading'}
+            className="rounded-lg border border-gray-700 p-2 text-gray-400 transition-colors hover:text-white disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD]"
+            aria-label="Refresh events"
+          >
+            <RefreshCw className={`h-4 w-4 ${state === 'loading' ? 'animate-spin' : ''}`} aria-hidden />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4">
+          {state === 'loading' && (
+            <div className="space-y-2" aria-busy="true" aria-label="Loading on-chain events">
+              {[0, 1, 2, 3].map((i) => (
+                <div key={i} className="h-20 animate-pulse rounded-xl bg-white/5" />
+              ))}
+            </div>
+          )}
+
+          {state === 'error' && (
+            <div className="rounded-xl border border-red-500/20 bg-red-500/10 p-4" role="alert">
+              <div className="flex items-start gap-2">
+                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" aria-hidden />
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-red-400">Could not load events</p>
+                  <p className="mt-1 break-words text-xs text-red-300/80">{error}</p>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={refresh}
+                className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-red-400/30 px-3 py-1.5 text-xs font-bold text-red-100 transition-colors hover:bg-red-400/10"
+              >
+                <RefreshCw className="h-3 w-3" aria-hidden />
+                Retry
+              </button>
+            </div>
+          )}
+
+          {state === 'loaded' && visible.length === 0 && (
+            <div className="rounded-xl border border-dashed border-white/10 bg-white/[0.02] p-8 text-center">
+              <p className="text-sm font-semibold text-gray-300">
+                {isFiltered ? 'No events for that round' : 'No events yet'}
+              </p>
+              <p className="mt-1 text-xs text-gray-500">
+                {isFiltered
+                  ? 'Clear the filter to see all recent events.'
+                  : 'Settlement events will appear here once rounds resolve on-chain.'}
+              </p>
+              {isFiltered && (
+                <button
+                  type="button"
+                  onClick={() => setRoundFilter('')}
+                  className="mt-3 rounded-lg border border-gray-700 px-3 py-1.5 text-xs font-semibold text-gray-300 transition-colors hover:text-white"
+                >
+                  Clear filter
+                </button>
+              )}
+            </div>
+          )}
+
+          {state === 'loaded' && visible.length > 0 && (
+            <ul className="space-y-2">
+              {visible.map((event) => (
+                <EventRow key={event.id} event={event} />
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {state === 'loaded' && events.length > 0 && (
+          <p className="border-t border-white/5 px-4 py-3 text-xs text-gray-500">
+            Showing {visible.length} of {events.length} recent events
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,6 +7,8 @@ import { Link, useLocation } from 'react-router-dom';
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { Menu, X, Search } from 'lucide-react';
 import { useWalletStore, selectIsWalletConnected } from '../store/useWalletStore';
+import WalletPicker from './WalletPicker';
+import type { WalletId } from '../lib/wallets';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import Logo from '../assets/logo.svg';
 import { MODAL_OVERLAY, PANEL_SLIDE_RIGHT } from '../utils/motion';
@@ -64,10 +66,27 @@ export default function Navbar() {
   const currentLanguage = (i18n.language || 'en').split('-')[0];
 
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [pickedWallet, setPickedWallet] = useState<WalletId | null>(null);
   const drawerRef = useRef<HTMLDivElement>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
 
   const closeMenu = useCallback(() => setIsMobileMenuOpen(false), []);
+
+  // Only Freighter is wired today; the picker disables every other adapter, so a
+  // selection always resolves to the store's Freighter connect flow.
+  const handleSelectWallet = useCallback(
+    async (id: WalletId) => {
+      setPickedWallet(id);
+      try {
+        await connect();
+        setIsPickerOpen(false);
+      } finally {
+        setPickedWallet(null);
+      }
+    },
+    [connect],
+  );
 
   const handleLanguageChange = (event: ChangeEvent<HTMLSelectElement>) => {
     void i18n.changeLanguage(event.target.value);
@@ -196,7 +215,7 @@ export default function Navbar() {
  
               <button
                 type="button"
-                onClick={() => void connect()}
+                onClick={() => setIsPickerOpen(true)}
                 disabled={isConnecting}
                 className="btn-primary rounded-lg px-4 py-2 text-sm font-semibold disabled:opacity-60"
               >
@@ -303,8 +322,8 @@ export default function Navbar() {
               <button
                 type="button"
                 onClick={() => {
-                  void connect();
-                  if (isConnected) closeMenu(); // optional: keep open if starting connect flow
+                  closeMenu();
+                  setIsPickerOpen(true);
                 }}
                 disabled={isConnecting}
                 className="btn-primary w-full rounded-lg px-4 py-3 text-sm font-semibold disabled:opacity-60"
@@ -315,6 +334,14 @@ export default function Navbar() {
           </div>
         </div>
       )}
+
+      <WalletPicker
+        isOpen={isPickerOpen}
+        onClose={() => setIsPickerOpen(false)}
+        onSelect={handleSelectWallet}
+        isConnecting={isConnecting}
+        connectingId={pickedWallet}
+      />
     </>
   );
 }

--- a/src/components/WalletConnect.test.tsx
+++ b/src/components/WalletConnect.test.tsx
@@ -8,6 +8,19 @@ import { useAuthStore } from '../store/useAuthStore';
 vi.mock('../store/useWalletStore');
 vi.mock('../store/useAuthStore');
 
+// Report Freighter as installed so the picker offers it in jsdom.
+vi.mock('../lib/wallets', async () => {
+  const actual = await vi.importActual<typeof import('../lib/wallets')>('../lib/wallets');
+  return {
+    ...actual,
+    WALLET_ADAPTERS: actual.WALLET_ADAPTERS.map((adapter) =>
+      adapter.id === 'freighter'
+        ? { ...adapter, isAvailable: async () => ({ isAvailable: true }) }
+        : adapter,
+    ),
+  };
+});
+
 // Mock Lucide icons
 vi.mock('lucide-react', () => ({
   Loader2: ({ className, ...props }: any) => <div data-testid="loader-icon" className={className} {...props} />,
@@ -16,6 +29,8 @@ vi.mock('lucide-react', () => ({
   Wallet: ({ className, ...props }: any) => <div data-testid="wallet-icon" className={className} {...props} />,
   ShieldCheck: ({ className, ...props }: any) => <div data-testid="shield-icon" className={className} {...props} />,
   RefreshCw: ({ className, ...props }: any) => <div data-testid="refresh-icon" className={className} {...props} />,
+  // Used by the WalletPicker rendered alongside the connect button.
+  X: ({ className, ...props }: any) => <div data-testid="close-icon" className={className} {...props} />,
 }));
 
 const mockWalletStore = {
@@ -69,13 +84,29 @@ describe('WalletConnect', () => {
       expect(screen.getByTestId('wallet-icon')).toBeInTheDocument();
     });
 
-    it('calls connect when connect button is clicked', () => {
+    it('opens the wallet picker when the connect button is clicked', () => {
       render(<WalletConnect />);
 
-      const connectButton = screen.getByRole('button', { name: /connect wallet/i });
-      fireEvent.click(connectButton);
+      expect(screen.queryByRole('dialog', { name: /connect a wallet/i })).not.toBeInTheDocument();
 
-      expect(mockWalletStore.connect).toHaveBeenCalledTimes(1);
+      fireEvent.click(screen.getByRole('button', { name: /connect wallet/i }));
+
+      // Wallet choice is now made in the picker rather than connecting immediately.
+      expect(screen.getByRole('dialog', { name: /connect a wallet/i })).toBeInTheDocument();
+      expect(mockWalletStore.connect).not.toHaveBeenCalled();
+    });
+
+    it('calls connect once Freighter is chosen in the picker', async () => {
+      mockWalletStore.connect.mockResolvedValue(undefined);
+      render(<WalletConnect />);
+
+      fireEvent.click(screen.getByRole('button', { name: /connect wallet/i }));
+
+      const freighterOption = await screen.findByRole('button', { name: /freighter/i });
+      await waitFor(() => expect(freighterOption).not.toBeDisabled());
+      fireEvent.click(freighterOption);
+
+      await waitFor(() => expect(mockWalletStore.connect).toHaveBeenCalledTimes(1));
     });
 
     it('has correct styling for connect button', () => {

--- a/src/components/WalletConnect.tsx
+++ b/src/components/WalletConnect.tsx
@@ -1,8 +1,10 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useWalletStore } from '../store/useWalletStore';
 import { useAuthStore } from '../store/useAuthStore';
 import { Loader2, AlertCircle, LogOut, Wallet, ShieldCheck, RefreshCw } from 'lucide-react';
 import clsx from 'clsx';
+import WalletPicker from './WalletPicker';
+import type { WalletId } from '../lib/wallets';
 
 const focusRing =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900';
@@ -21,10 +23,24 @@ const WalletConnect = () => {
     clearError,
   } = useWalletStore();
   const { isAuthenticated } = useAuthStore();
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [pickedWallet, setPickedWallet] = useState<WalletId | null>(null);
 
   useEffect(() => {
     void checkConnection();
   }, [checkConnection]);
+
+  // Only Freighter is wired today; the picker disables every other adapter, so a
+  // selection always resolves to the store's Freighter connect flow.
+  const handleSelectWallet = async (id: WalletId) => {
+    setPickedWallet(id);
+    try {
+      await connect();
+      setIsPickerOpen(false);
+    } finally {
+      setPickedWallet(null);
+    }
+  };
 
   const shortAddress = publicKey
     ? `${publicKey.slice(0, 4)}...${publicKey.slice(-4)}`
@@ -166,35 +182,45 @@ const WalletConnect = () => {
   }
 
   return (
-    <button
-      type="button"
-      onClick={() => void connect()}
-      disabled={status === 'connecting' || status === 'checking'}
-      className={clsx(
-        'flex items-center gap-2 px-4 py-2 rounded-lg font-semibold transition-all duration-200',
-        'bg-[#2C4BFD] hover:bg-[#1a3bf0] text-white shadow-lg shadow-blue-500/20',
-        'disabled:opacity-70 disabled:cursor-not-allowed',
-        focusRing
-      )}
-      aria-busy={status === 'connecting' || status === 'checking'}
-    >
-      {status === 'connecting' ? (
-        <>
-          <Loader2 className="w-4 h-4 animate-spin" aria-hidden />
-          <span>Connecting…</span>
-        </>
-      ) : status === 'checking' ? (
-        <>
-          <Loader2 className="w-4 h-4 animate-spin" aria-hidden />
-          <span>Checking wallet…</span>
-        </>
-      ) : (
-        <>
-          <Wallet className="w-4 h-4" aria-hidden />
-          <span>Connect Wallet</span>
-        </>
-      )}
-    </button>
+    <>
+      <button
+        type="button"
+        onClick={() => setIsPickerOpen(true)}
+        disabled={status === 'connecting' || status === 'checking'}
+        className={clsx(
+          'flex items-center gap-2 px-4 py-2 rounded-lg font-semibold transition-all duration-200',
+          'bg-[#2C4BFD] hover:bg-[#1a3bf0] text-white shadow-lg shadow-blue-500/20',
+          'disabled:opacity-70 disabled:cursor-not-allowed',
+          focusRing
+        )}
+        aria-busy={status === 'connecting' || status === 'checking'}
+      >
+        {status === 'connecting' ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" aria-hidden />
+            <span>Connecting…</span>
+          </>
+        ) : status === 'checking' ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" aria-hidden />
+            <span>Checking wallet…</span>
+          </>
+        ) : (
+          <>
+            <Wallet className="w-4 h-4" aria-hidden />
+            <span>Connect Wallet</span>
+          </>
+        )}
+      </button>
+
+      <WalletPicker
+        isOpen={isPickerOpen}
+        onClose={() => setIsPickerOpen(false)}
+        onSelect={handleSelectWallet}
+        isConnecting={status === 'connecting'}
+        connectingId={pickedWallet}
+      />
+    </>
   );
 };
 

--- a/src/components/WalletPicker.test.tsx
+++ b/src/components/WalletPicker.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import WalletPicker from './WalletPicker';
+
+const isAvailableMock = vi.fn();
+
+vi.mock('../lib/wallets', async () => {
+  const actual = await vi.importActual<typeof import('../lib/wallets')>('../lib/wallets');
+  return {
+    ...actual,
+    WALLET_ADAPTERS: [
+      {
+        id: 'freighter',
+        name: 'Freighter',
+        description: 'Browser extension by the Stellar Development Foundation',
+        isImplemented: true,
+        isAvailable: () => isAvailableMock(),
+        connect: vi.fn(),
+        signMessage: vi.fn(),
+        signTransaction: vi.fn(),
+      },
+      {
+        id: 'albedo',
+        name: 'Albedo',
+        description: 'Web-based signer — no extension required',
+        isImplemented: false,
+        isAvailable: async () => ({ isAvailable: false, reason: 'NOT_IMPLEMENTED' }),
+        connect: vi.fn(),
+        signMessage: vi.fn(),
+        signTransaction: vi.fn(),
+      },
+    ],
+  };
+});
+
+describe('WalletPicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isAvailableMock.mockResolvedValue({ isAvailable: true });
+  });
+
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <WalletPicker isOpen={false} onClose={vi.fn()} onSelect={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a row per registered adapter as a modal dialog', async () => {
+    render(<WalletPicker isOpen onClose={vi.fn()} onSelect={vi.fn()} />);
+
+    expect(screen.getByRole('dialog', { name: /connect a wallet/i })).toBeInTheDocument();
+    expect(screen.getByText('Freighter')).toBeInTheDocument();
+    expect(screen.getByText('Albedo')).toBeInTheDocument();
+    await waitFor(() => expect(isAvailableMock).toHaveBeenCalled());
+  });
+
+  it('marks unimplemented adapters as coming soon and disables them', () => {
+    render(<WalletPicker isOpen onClose={vi.fn()} onSelect={vi.fn()} />);
+
+    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /albedo/i })).toBeDisabled();
+  });
+
+  it('calls onSelect with the wallet id when an available adapter is chosen', async () => {
+    const onSelect = vi.fn();
+    render(<WalletPicker isOpen onClose={vi.fn()} onSelect={onSelect} />);
+
+    const freighter = screen.getByRole('button', { name: /freighter/i });
+    await waitFor(() => expect(freighter).not.toBeDisabled());
+    fireEvent.click(freighter);
+
+    expect(onSelect).toHaveBeenCalledWith('freighter');
+  });
+
+  it('disables an implemented adapter that is not installed', async () => {
+    isAvailableMock.mockResolvedValue({ isAvailable: false, reason: 'NOT_INSTALLED' });
+
+    render(<WalletPicker isOpen onClose={vi.fn()} onSelect={vi.fn()} />);
+
+    expect(await screen.findByText(/not installed/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /freighter/i })).toBeDisabled();
+  });
+
+  it('closes when the close button is pressed', () => {
+    const onClose = vi.fn();
+    render(<WalletPicker isOpen onClose={onClose} onSelect={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /close wallet picker/i }));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    render(<WalletPicker isOpen onClose={onClose} onSelect={vi.fn()} />);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/WalletPicker.tsx
+++ b/src/components/WalletPicker.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useRef, useState } from 'react';
+import { Loader2, Wallet, X } from 'lucide-react';
+import { WALLET_ADAPTERS, type WalletAdapter, type WalletId } from '../lib/wallets';
+import { useFocusTrap } from '../hooks/useFocusTrap';
+import { MODAL_CONTENT, MODAL_OVERLAY } from '../utils/motion';
+
+interface WalletPickerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Called with the chosen wallet once the user picks an available adapter. */
+  onSelect: (id: WalletId) => void | Promise<void>;
+  /** True while the parent is completing the connection for the chosen wallet. */
+  isConnecting?: boolean;
+  /** Wallet currently being connected, used to scope the spinner to one row. */
+  connectingId?: WalletId | null;
+}
+
+type AvailabilityMap = Partial<Record<WalletId, boolean>>;
+
+function WalletRow({
+  adapter,
+  isAvailable,
+  isChecking,
+  isConnecting,
+  onSelect,
+}: {
+  adapter: WalletAdapter;
+  isAvailable: boolean | undefined;
+  isChecking: boolean;
+  isConnecting: boolean;
+  onSelect: () => void;
+}) {
+  const isDisabled = !adapter.isImplemented || isAvailable === false || isConnecting;
+
+  let badge: string | null = null;
+  if (!adapter.isImplemented) {
+    badge = 'Coming soon';
+  } else if (isChecking) {
+    badge = 'Checking…';
+  } else if (isAvailable === false) {
+    badge = 'Not installed';
+  }
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onSelect}
+        disabled={isDisabled}
+        aria-describedby={badge ? `wallet-badge-${adapter.id}` : undefined}
+        className="flex w-full items-center gap-3 rounded-xl border border-gray-800 bg-gray-950/70 px-4 py-3 text-left transition-colors enabled:hover:border-[#2C4BFD]/50 enabled:hover:bg-white/[0.03] disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD]"
+      >
+        <span
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-gradient-to-tr from-[#2C4BFD] to-[#22D3EE] text-white"
+          aria-hidden
+        >
+          <Wallet className="h-4 w-4" />
+        </span>
+
+        <span className="min-w-0 flex-1">
+          <span className="flex items-center gap-2">
+            <span className="text-sm font-bold text-white">{adapter.name}</span>
+            {badge && (
+              <span
+                id={`wallet-badge-${adapter.id}`}
+                className="rounded border border-white/10 bg-white/5 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-gray-400"
+              >
+                {badge}
+              </span>
+            )}
+          </span>
+          <span className="mt-0.5 block truncate text-xs text-gray-500">{adapter.description}</span>
+        </span>
+
+        {isConnecting && (
+          <Loader2 className="h-4 w-4 shrink-0 animate-spin text-[#22D3EE]" aria-hidden />
+        )}
+      </button>
+    </li>
+  );
+}
+
+/**
+ * Wallet selection modal.
+ *
+ * Renders one row per registered `WalletAdapter`. Freighter is fully wired;
+ * adapters that report `isImplemented: false` render disabled as "Coming soon"
+ * so the picker advertises the roadmap without offering a dead path.
+ */
+export default function WalletPicker({
+  isOpen,
+  onClose,
+  onSelect,
+  isConnecting = false,
+  connectingId = null,
+}: WalletPickerProps) {
+  const [availability, setAvailability] = useState<AvailabilityMap>({});
+  const [isChecking, setIsChecking] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useFocusTrap(dialogRef, {
+    active: isOpen,
+    onEscape: onClose,
+    initialFocusRef: closeButtonRef,
+  });
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    let cancelled = false;
+
+    const run = async () => {
+      setIsChecking(true);
+
+      const entries = await Promise.all(
+        WALLET_ADAPTERS.map(async (adapter) => {
+          if (!adapter.isImplemented) return [adapter.id, false] as const;
+          try {
+            const { isAvailable } = await adapter.isAvailable();
+            return [adapter.id, isAvailable] as const;
+          } catch {
+            return [adapter.id, false] as const;
+          }
+        }),
+      );
+
+      if (cancelled) return;
+      setAvailability(Object.fromEntries(entries) as AvailabilityMap);
+      setIsChecking(false);
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
+      <div
+        className={`absolute inset-0 bg-black/60 backdrop-blur-sm ${MODAL_OVERLAY}`}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="wallet-picker-title"
+        className={`glass-card relative z-10 w-full max-w-sm rounded-2xl border border-gray-800 bg-gray-900 p-6 text-white shadow-2xl ${MODAL_CONTENT}`}
+      >
+        <button
+          ref={closeButtonRef}
+          type="button"
+          onClick={onClose}
+          className="absolute right-4 top-4 rounded p-1 text-gray-400 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD]"
+          aria-label="Close wallet picker"
+        >
+          <X className="h-4 w-4" aria-hidden />
+        </button>
+
+        <h2 id="wallet-picker-title" className="mb-1 text-lg font-bold">
+          Connect a wallet
+        </h2>
+        <p className="mb-5 text-sm text-gray-400">
+          Choose how you want to sign transactions on Xelma.
+        </p>
+
+        <ul className="space-y-2">
+          {WALLET_ADAPTERS.map((adapter) => (
+            <WalletRow
+              key={adapter.id}
+              adapter={adapter}
+              isAvailable={availability[adapter.id]}
+              isChecking={isChecking && adapter.isImplemented}
+              isConnecting={isConnecting && connectingId === adapter.id}
+              onSelect={() => void onSelect(adapter.id)}
+            />
+          ))}
+        </ul>
+
+        <p className="mt-5 text-xs text-gray-500">
+          New to Stellar wallets?{' '}
+          <a
+            href="https://www.freighter.app/"
+            target="_blank"
+            rel="noreferrer"
+            className="text-[#BEC7FE] underline hover:text-white"
+          >
+            Install Freighter
+          </a>{' '}
+          to get started.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/XdrPreviewDrawer.test.tsx
+++ b/src/components/XdrPreviewDrawer.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import XdrPreviewDrawer from './XdrPreviewDrawer';
+
+const XDR = 'AAAAAgAAAABexampleXDRpayloadForTests==';
+const HASH = 'abc123def456';
+const PASSPHRASE = 'Test SDF Network ; September 2015';
+
+function renderDrawer() {
+  return render(<XdrPreviewDrawer xdr={XDR} hash={HASH} networkPassphrase={PASSPHRASE} />);
+}
+
+function expand() {
+  fireEvent.click(screen.getByRole('button', { name: /advanced/i }));
+}
+
+describe('XdrPreviewDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is collapsed by default so it does not block casual users', () => {
+    renderDrawer();
+
+    expect(screen.getByRole('button', { name: /advanced/i })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    expect(screen.queryByText(XDR)).not.toBeInTheDocument();
+  });
+
+  it('reveals the XDR, hash, and network once expanded', () => {
+    renderDrawer();
+
+    expand();
+
+    expect(screen.getByRole('button', { name: /advanced/i })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByText(XDR)).toBeInTheDocument();
+    expect(screen.getByText(HASH)).toBeInTheDocument();
+    expect(screen.getByText(PASSPHRASE)).toBeInTheDocument();
+  });
+
+  it('collapses again when toggled a second time', () => {
+    renderDrawer();
+
+    expand();
+    expand();
+
+    expect(screen.getByRole('button', { name: /advanced/i })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    expect(screen.queryByText(XDR)).not.toBeInTheDocument();
+  });
+
+  it('copies the XDR to the clipboard and confirms', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    renderDrawer();
+    expand();
+    fireEvent.click(screen.getByRole('button', { name: /copy transaction xdr/i }));
+
+    expect(writeText).toHaveBeenCalledWith(XDR);
+    await waitFor(() => {
+      expect(screen.getByText(/xdr copied to clipboard/i)).toBeInTheDocument();
+    });
+  });
+
+  it('tells the user to copy manually when the clipboard is unavailable', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    renderDrawer();
+    expand();
+    fireEvent.click(screen.getByRole('button', { name: /copy transaction xdr/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/could not access the clipboard/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/XdrPreviewDrawer.tsx
+++ b/src/components/XdrPreviewDrawer.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+import { Check, ChevronDown, ChevronRight, Copy } from 'lucide-react';
+
+interface XdrPreviewDrawerProps {
+  /** Base64 XDR of the prepared, unsigned transaction. */
+  xdr: string;
+  /** Hash of the prepared transaction. */
+  hash: string;
+  /** Network passphrase the transaction is built against. */
+  networkPassphrase?: string;
+}
+
+async function writeToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Optional "Advanced" drawer exposing the raw transaction XDR and hash before
+ * the user approves in Freighter.
+ *
+ * Collapsed by default so the casual prediction path is unchanged — only users
+ * who deliberately expand it see the payload.
+ */
+export default function XdrPreviewDrawer({ xdr, hash, networkPassphrase }: XdrPreviewDrawerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [copyFailed, setCopyFailed] = useState(false);
+
+  const handleCopy = async () => {
+    const ok = await writeToClipboard(xdr);
+    setCopied(ok);
+    setCopyFailed(!ok);
+    window.setTimeout(() => {
+      setCopied(false);
+      setCopyFailed(false);
+    }, 2000);
+  };
+
+  return (
+    <div className="mb-5 rounded-xl border border-gray-800 bg-gray-950/70">
+      <button
+        type="button"
+        onClick={() => setIsOpen((v) => !v)}
+        aria-expanded={isOpen}
+        aria-controls="xdr-preview-body"
+        className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left transition-colors hover:bg-white/[0.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD]"
+      >
+        <span className="text-xs font-bold uppercase tracking-wider text-gray-500">
+          Advanced — transaction preview
+        </span>
+        {isOpen ? (
+          <ChevronDown className="h-4 w-4 shrink-0 text-gray-500" aria-hidden />
+        ) : (
+          <ChevronRight className="h-4 w-4 shrink-0 text-gray-500" aria-hidden />
+        )}
+      </button>
+
+      {isOpen && (
+        <div id="xdr-preview-body" className="border-t border-gray-800 px-4 py-3">
+          <p className="mb-3 text-xs text-gray-500">
+            This is the exact unsigned transaction Freighter will ask you to approve.
+          </p>
+
+          <div className="mb-3">
+            <span className="mb-1 block text-xs font-semibold text-gray-400">Transaction hash</span>
+            <p className="break-all font-mono text-xs text-gray-300">{hash}</p>
+          </div>
+
+          {networkPassphrase && (
+            <div className="mb-3">
+              <span className="mb-1 block text-xs font-semibold text-gray-400">Network</span>
+              <p className="break-words font-mono text-xs text-gray-300">{networkPassphrase}</p>
+            </div>
+          )}
+
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <span className="text-xs font-semibold text-gray-400">XDR</span>
+            <button
+              type="button"
+              onClick={() => void handleCopy()}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-gray-700 px-2.5 py-1 text-xs font-semibold text-gray-300 transition-colors hover:border-gray-600 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2C4BFD]"
+              aria-label="Copy transaction XDR to clipboard"
+            >
+              {copied ? (
+                <>
+                  <Check className="h-3 w-3 text-green-400" aria-hidden />
+                  Copied
+                </>
+              ) : (
+                <>
+                  <Copy className="h-3 w-3" aria-hidden />
+                  Copy
+                </>
+              )}
+            </button>
+          </div>
+
+          <pre className="max-h-32 overflow-auto rounded-lg bg-black/40 p-3 text-[11px] leading-relaxed">
+            <code className="break-all whitespace-pre-wrap font-mono text-gray-400">{xdr}</code>
+          </pre>
+
+          <p aria-live="polite" className="mt-2 text-xs">
+            {copied && <span className="text-green-400">XDR copied to clipboard.</span>}
+            {copyFailed && (
+              <span className="text-amber-400">
+                Could not access the clipboard — select the XDR above and copy manually.
+              </span>
+            )}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/__tests__/xelma-contract.test.ts
+++ b/src/lib/__tests__/xelma-contract.test.ts
@@ -119,7 +119,8 @@ describe('Smart Contract Bindings', () => {
   it('throws error when user rejects Freighter signature', async () => {
     vi.mocked(signTransaction).mockResolvedValue({ error: 'User rejected' } as any);
 
-    await expect(place_bet(userPublicKey, 'UP', '10')).rejects.toThrow(/Freighter signing rejected/);
+    // The wallet adapter surfaces the wallet's own rejection message.
+    await expect(place_bet(userPublicKey, 'UP', '10')).rejects.toThrow(/User rejected/);
   });
 
   it('invokes onStatus callback with preparing/signing/submitting', async () => {

--- a/src/lib/explorer.ts
+++ b/src/lib/explorer.ts
@@ -1,0 +1,20 @@
+/**
+ * Network-aware StellarExpert explorer links.
+ */
+
+import { IS_MAINNET } from './horizon';
+
+const EXPLORER_BASE = 'https://stellar.expert/explorer';
+
+/** `public` or `testnet`, matching StellarExpert's URL segment. */
+export const EXPLORER_NETWORK = IS_MAINNET ? 'public' : 'testnet';
+
+/** Explorer URL for a transaction hash. */
+export function txUrl(hash: string): string {
+  return `${EXPLORER_BASE}/${EXPLORER_NETWORK}/tx/${hash}`;
+}
+
+/** Explorer URL for an account address. */
+export function accountUrl(address: string): string {
+  return `${EXPLORER_BASE}/${EXPLORER_NETWORK}/account/${address}`;
+}

--- a/src/lib/horizon.test.ts
+++ b/src/lib/horizon.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchAccountBalances, formatBalance, HorizonError, HORIZON_URL } from './horizon';
+
+const ADDRESS = 'GCEXAMPLE7ADDRESS7FOR7TESTS7ONLY7AAAAAAAAAAAAAAAAAAAAAAAA';
+
+function mockFetchOnce(value: unknown) {
+  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(value);
+}
+
+describe('horizon', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('HORIZON_URL', () => {
+    it('defaults to the testnet endpoint and has no trailing slash', () => {
+      expect(HORIZON_URL).toBe('https://horizon-testnet.stellar.org');
+      expect(HORIZON_URL.endsWith('/')).toBe(false);
+    });
+  });
+
+  describe('fetchAccountBalances', () => {
+    it('requests the account from the configured Horizon URL', async () => {
+      mockFetchOnce({ ok: true, status: 200, json: async () => ({ balances: [] }) });
+
+      await fetchAccountBalances(ADDRESS);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${HORIZON_URL}/accounts/${ADDRESS}`,
+        expect.anything(),
+      );
+    });
+
+    it('splits the native balance out from trustlines', async () => {
+      mockFetchOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          balances: [
+            { asset_type: 'credit_alphanum4', asset_code: 'USDC', asset_issuer: 'GISSUER', balance: '25.5000000', limit: '1000' },
+            { asset_type: 'native', balance: '101.9999999' },
+          ],
+        }),
+      });
+
+      const result = await fetchAccountBalances(ADDRESS);
+
+      expect(result.isUnfunded).toBe(false);
+      expect(result.native).toMatchObject({ code: 'XLM', isNative: true, balance: '101.9999999' });
+      expect(result.trustlines).toHaveLength(1);
+      expect(result.trustlines[0]).toMatchObject({
+        code: 'USDC',
+        issuer: 'GISSUER',
+        isNative: false,
+        limit: '1000',
+        isAuthorized: true,
+      });
+    });
+
+    it('treats a 404 as an unfunded account rather than an error', async () => {
+      mockFetchOnce({ ok: false, status: 404, json: async () => ({}) });
+
+      const result = await fetchAccountBalances(ADDRESS);
+
+      expect(result).toEqual({ native: null, trustlines: [], isUnfunded: true });
+    });
+
+    it('marks a trustline unauthorized when Horizon reports is_authorized false', async () => {
+      mockFetchOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          balances: [
+            { asset_type: 'credit_alphanum4', asset_code: 'EURC', asset_issuer: 'GISSUER', balance: '0', is_authorized: false },
+          ],
+        }),
+      });
+
+      const result = await fetchAccountBalances(ADDRESS);
+
+      expect(result.trustlines[0].isAuthorized).toBe(false);
+    });
+
+    it('throws a HorizonError on a non-404 failure status', async () => {
+      mockFetchOnce({ ok: false, status: 500, json: async () => ({}) });
+
+      await expect(fetchAccountBalances(ADDRESS)).rejects.toBeInstanceOf(HorizonError);
+    });
+
+    it('throws a HorizonError when the network request fails', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('offline'));
+
+      await expect(fetchAccountBalances(ADDRESS)).rejects.toBeInstanceOf(HorizonError);
+    });
+
+    it('returns an empty result when Horizon omits the balances array', async () => {
+      mockFetchOnce({ ok: true, status: 200, json: async () => ({}) });
+
+      const result = await fetchAccountBalances(ADDRESS);
+
+      expect(result.native).toBeNull();
+      expect(result.trustlines).toEqual([]);
+    });
+  });
+
+  describe('formatBalance', () => {
+    it('formats to two decimal places by default', () => {
+      expect(formatBalance('101.9999999')).toBe('102.00');
+      expect(formatBalance('0')).toBe('0.00');
+    });
+
+    it('falls back to zero for unparseable input', () => {
+      expect(formatBalance('not-a-number')).toBe('0.00');
+    });
+  });
+});

--- a/src/lib/horizon.ts
+++ b/src/lib/horizon.ts
@@ -1,0 +1,126 @@
+/**
+ * Network-aware Horizon configuration and account helpers.
+ *
+ * The Horizon endpoint is resolved from `VITE_STELLAR_HORIZON_URL` when set.
+ * Otherwise it is derived from `VITE_STELLAR_NETWORK` so that a single network
+ * switch moves the whole app between testnet and mainnet.
+ */
+
+const TESTNET_HORIZON = 'https://horizon-testnet.stellar.org';
+const PUBLIC_HORIZON = 'https://horizon.stellar.org';
+
+const NETWORK = (import.meta.env.VITE_STELLAR_NETWORK ?? 'TESTNET').toUpperCase();
+
+export const IS_MAINNET = NETWORK === 'PUBLIC' || NETWORK === 'MAINNET';
+
+/** Root Horizon URL for the configured network, without a trailing slash. */
+export const HORIZON_URL: string = (
+  import.meta.env.VITE_STELLAR_HORIZON_URL || (IS_MAINNET ? PUBLIC_HORIZON : TESTNET_HORIZON)
+).replace(/\/+$/, '');
+
+/** Raw balance entry as returned by Horizon's `/accounts/{id}` endpoint. */
+interface HorizonBalance {
+  asset_type: string;
+  balance: string;
+  asset_code?: string;
+  asset_issuer?: string;
+  limit?: string;
+  is_authorized?: boolean;
+}
+
+/** A single asset line, normalized for display. */
+export interface AssetBalance {
+  /** `XLM` for the native asset, otherwise the 4- or 12-character asset code. */
+  code: string;
+  /** Balance formatted to 7 decimal places (Horizon's native precision). */
+  balance: string;
+  /** True for the native XLM balance. */
+  isNative: boolean;
+  /** Issuer G-address for trustlines; null for native. */
+  issuer: string | null;
+  /** Trustline limit, when Horizon reports one. */
+  limit: string | null;
+  /** False when the issuer has not authorized this trustline. */
+  isAuthorized: boolean;
+}
+
+export interface AccountBalances {
+  native: AssetBalance | null;
+  trustlines: AssetBalance[];
+  /** True when the account does not exist on this network yet (Horizon 404). */
+  isUnfunded: boolean;
+}
+
+export class HorizonError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'HorizonError';
+  }
+}
+
+function normalizeBalance(entry: HorizonBalance): AssetBalance {
+  const isNative = entry.asset_type === 'native';
+  return {
+    code: isNative ? 'XLM' : entry.asset_code ?? 'UNKNOWN',
+    balance: entry.balance,
+    isNative,
+    issuer: isNative ? null : entry.asset_issuer ?? null,
+    limit: entry.limit ?? null,
+    isAuthorized: entry.is_authorized !== false,
+  };
+}
+
+/**
+ * Fetches balances and trustlines for a G-address from Horizon.
+ *
+ * An unfunded account (Horizon 404) resolves to `isUnfunded: true` rather than
+ * throwing, so the UI can render an empty state instead of an error.
+ *
+ * @throws {HorizonError} when the request fails or the response is unusable.
+ */
+export async function fetchAccountBalances(
+  address: string,
+  signal?: AbortSignal,
+): Promise<AccountBalances> {
+  let response: Response;
+  try {
+    response = await fetch(`${HORIZON_URL}/accounts/${address}`, { signal });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') throw err;
+    throw new HorizonError('Could not reach Horizon. Check your connection and try again.');
+  }
+
+  if (response.status === 404) {
+    return { native: null, trustlines: [], isUnfunded: true };
+  }
+
+  if (!response.ok) {
+    throw new HorizonError(`Horizon returned ${response.status}. Try again in a moment.`);
+  }
+
+  let payload: { balances?: HorizonBalance[] };
+  try {
+    payload = await response.json();
+  } catch {
+    throw new HorizonError('Received an unreadable response from Horizon.');
+  }
+
+  const balances = Array.isArray(payload.balances) ? payload.balances : [];
+  const normalized = balances.map(normalizeBalance);
+
+  return {
+    native: normalized.find((b) => b.isNative) ?? null,
+    trustlines: normalized.filter((b) => !b.isNative),
+    isUnfunded: false,
+  };
+}
+
+/** Formats a raw Horizon balance string for compact display. */
+export function formatBalance(raw: string, decimals = 2): string {
+  const value = Number.parseFloat(raw);
+  if (!Number.isFinite(value)) return '0.00';
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}

--- a/src/lib/prediction-events.test.ts
+++ b/src/lib/prediction-events.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { nativeToScVal } from '@stellar/stellar-sdk';
+
+const getLatestLedger = vi.fn();
+const getEvents = vi.fn();
+
+vi.mock('@stellar/stellar-sdk', async () => {
+  const actual = await vi.importActual<typeof import('@stellar/stellar-sdk')>(
+    '@stellar/stellar-sdk',
+  );
+  return {
+    ...actual,
+    rpc: {
+      ...actual.rpc,
+      Server: class {
+        getLatestLedger = getLatestLedger;
+        getEvents = getEvents;
+      },
+    },
+  };
+});
+
+const { fetchPredictionEvents, filterByRound, PredictionEventsError } = await import(
+  './prediction-events'
+);
+type PredictionEvent = Awaited<ReturnType<typeof fetchPredictionEvents>>[number];
+
+function rawEvent(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'evt-1',
+    ledger: 1000,
+    ledgerClosedAt: '2026-07-30T10:00:00Z',
+    txHash: 'txhash1',
+    topic: [nativeToScVal('settle', { type: 'symbol' }), nativeToScVal(7, { type: 'u32' })],
+    value: nativeToScVal(42, { type: 'u32' }),
+    ...overrides,
+  };
+}
+
+describe('prediction-events', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getLatestLedger.mockResolvedValue({ sequence: 50_000 });
+  });
+
+  describe('fetchPredictionEvents', () => {
+    it('queries the contract from a ledger window behind the latest ledger', async () => {
+      getEvents.mockResolvedValue({ events: [] });
+
+      await fetchPredictionEvents();
+
+      const request = getEvents.mock.calls[0][0];
+      expect(request.startLedger).toBeGreaterThan(0);
+      expect(request.startLedger).toBeLessThan(50_000);
+      expect(request.filters[0].type).toBe('contract');
+    });
+
+    it('decodes an event and classifies a settle topic as a settlement', async () => {
+      getEvents.mockResolvedValue({ events: [rawEvent()] });
+
+      const [event] = await fetchPredictionEvents();
+
+      expect(event.name).toBe('settle');
+      expect(event.kind).toBe('settlement');
+      expect(event.ledger).toBe(1000);
+      expect(event.txHash).toBe('txhash1');
+    });
+
+    it('reads the round id from a numeric topic', async () => {
+      getEvents.mockResolvedValue({ events: [rawEvent()] });
+
+      const [event] = await fetchPredictionEvents();
+
+      expect(event.roundId).toBe('7');
+    });
+
+    it('falls back to a round_id field on the payload', async () => {
+      getEvents.mockResolvedValue({
+        events: [
+          rawEvent({
+            topic: [nativeToScVal('bet_placed', { type: 'symbol' })],
+            value: nativeToScVal({ round_id: 12 }),
+          }),
+        ],
+      });
+
+      const [event] = await fetchPredictionEvents();
+
+      expect(event.roundId).toBe('12');
+      expect(event.kind).toBe('prediction');
+    });
+
+    it('returns null for a round id when neither topics nor payload carry one', async () => {
+      getEvents.mockResolvedValue({
+        events: [
+          rawEvent({
+            topic: [nativeToScVal('ping', { type: 'symbol' })],
+            value: nativeToScVal('nothing-useful'),
+          }),
+        ],
+      });
+
+      const [event] = await fetchPredictionEvents();
+
+      expect(event.roundId).toBeNull();
+      expect(event.kind).toBe('other');
+    });
+
+    it('returns an empty list when the contract has no events', async () => {
+      getEvents.mockResolvedValue({ events: [] });
+
+      await expect(fetchPredictionEvents()).resolves.toEqual([]);
+    });
+
+    it('throws a PredictionEventsError when the ledger lookup fails', async () => {
+      getLatestLedger.mockRejectedValue(new Error('rpc down'));
+
+      await expect(fetchPredictionEvents()).rejects.toBeInstanceOf(PredictionEventsError);
+    });
+
+    it('throws a PredictionEventsError when the event query fails', async () => {
+      getEvents.mockRejectedValue(new Error('rpc down'));
+
+      await expect(fetchPredictionEvents()).rejects.toBeInstanceOf(PredictionEventsError);
+    });
+  });
+
+  describe('filterByRound', () => {
+    const events = [
+      { roundId: '1' },
+      { roundId: '2' },
+      { roundId: null },
+    ] as PredictionEvent[];
+
+    it('returns every event for an empty filter', () => {
+      expect(filterByRound(events, '')).toHaveLength(3);
+      expect(filterByRound(events, '   ')).toHaveLength(3);
+    });
+
+    it('keeps only events matching the round id', () => {
+      expect(filterByRound(events, '2')).toEqual([{ roundId: '2' }]);
+    });
+
+    it('returns nothing when no event matches', () => {
+      expect(filterByRound(events, '99')).toEqual([]);
+    });
+  });
+});

--- a/src/lib/prediction-events.ts
+++ b/src/lib/prediction-events.ts
@@ -1,0 +1,145 @@
+/**
+ * Reads prediction and settlement events emitted by the Xelma contract.
+ *
+ * Events come from Soroban RPC `getEvents`, scanned backwards from the latest
+ * ledger. When RPC is unreachable or the contract has no event history, the
+ * caller receives an empty list and can render an empty state.
+ */
+
+import { rpc, scValToNative, type xdr } from '@stellar/stellar-sdk';
+
+const RPC_URL = import.meta.env.VITE_STELLAR_RPC_URL || 'https://soroban-testnet.stellar.org';
+const XELMA_CONTRACT_ID =
+  import.meta.env.VITE_XELMA_CONTRACT_ID ||
+  'CD7V3L7JIP52EXWLYSOWXND4F3N65QZ2R54H6M77Y3S37Z55XHLXELMA';
+
+const eventsRpc = new rpc.Server(RPC_URL);
+
+/**
+ * How many ledgers back to scan. Soroban RPC retains roughly 24h of events, and
+ * ledgers close about every 5s, so this covers the retention window.
+ */
+const LEDGER_LOOKBACK = 17_280;
+const DEFAULT_LIMIT = 50;
+
+export type PredictionEventKind = 'settlement' | 'prediction' | 'round' | 'other';
+
+export interface PredictionEvent {
+  /** RPC event id, unique per event. */
+  id: string;
+  /** First topic, the contract's event name (e.g. `settle`). */
+  name: string;
+  kind: PredictionEventKind;
+  /** Round id parsed from the event topics or payload, when present. */
+  roundId: string | null;
+  ledger: number;
+  /** ISO timestamp of the ledger close. */
+  timestamp: string;
+  /** Transaction hash, when RPC reports one. */
+  txHash: string | null;
+  /** Decoded event payload, for display. */
+  payload: unknown;
+}
+
+export class PredictionEventsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PredictionEventsError';
+  }
+}
+
+function classify(name: string): PredictionEventKind {
+  const lower = name.toLowerCase();
+  if (lower.includes('settle') || lower.includes('resolve') || lower.includes('payout')) {
+    return 'settlement';
+  }
+  if (lower.includes('bet') || lower.includes('predict')) return 'prediction';
+  if (lower.includes('round')) return 'round';
+  return 'other';
+}
+
+/** Decodes an ScVal, returning null when the value cannot be converted. */
+function decode(value: xdr.ScVal | undefined): unknown {
+  if (!value) return null;
+  try {
+    return scValToNative(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pulls a round id out of the decoded topics or payload.
+ *
+ * Contracts vary in where they put it — a later topic, or a `round_id` /
+ * `roundId` field on the payload — so both shapes are checked.
+ */
+function extractRoundId(topics: unknown[], payload: unknown): string | null {
+  for (const topic of topics.slice(1)) {
+    if (typeof topic === 'bigint' || typeof topic === 'number') return String(topic);
+    if (typeof topic === 'string' && /^\d+$/.test(topic)) return topic;
+  }
+
+  if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+    const record = payload as Record<string, unknown>;
+    const candidate = record.round_id ?? record.roundId ?? record.round;
+    if (typeof candidate === 'bigint' || typeof candidate === 'number') return String(candidate);
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+
+  return null;
+}
+
+/**
+ * Fetches recent contract events, newest first.
+ *
+ * @throws {PredictionEventsError} when RPC cannot be reached.
+ */
+export async function fetchPredictionEvents(limit = DEFAULT_LIMIT): Promise<PredictionEvent[]> {
+  let startLedger: number;
+  try {
+    const { sequence } = await eventsRpc.getLatestLedger();
+    startLedger = Math.max(1, sequence - LEDGER_LOOKBACK);
+  } catch {
+    throw new PredictionEventsError('Could not reach Stellar RPC. Try again in a moment.');
+  }
+
+  let response;
+  try {
+    response = await eventsRpc.getEvents({
+      startLedger,
+      filters: [{ type: 'contract', contractIds: [XELMA_CONTRACT_ID] }],
+      limit,
+    });
+  } catch {
+    throw new PredictionEventsError('Could not load on-chain events from Stellar RPC.');
+  }
+
+  const events = response.events ?? [];
+
+  return events
+    .map((event): PredictionEvent => {
+      const topics = (event.topic ?? []).map((t) => decode(t));
+      const payload = decode(event.value);
+      const name = typeof topics[0] === 'string' ? topics[0] : 'unknown';
+
+      return {
+        id: event.id,
+        name,
+        kind: classify(name),
+        roundId: extractRoundId(topics, payload),
+        ledger: event.ledger,
+        timestamp: event.ledgerClosedAt,
+        txHash: event.txHash ?? null,
+        payload,
+      };
+    })
+    .reverse();
+}
+
+/** Filters events to a single round id. An empty filter returns everything. */
+export function filterByRound(events: PredictionEvent[], roundId: string): PredictionEvent[] {
+  const trimmed = roundId.trim();
+  if (!trimmed) return events;
+  return events.filter((event) => event.roundId === trimmed);
+}

--- a/src/lib/wallets/freighter.ts
+++ b/src/lib/wallets/freighter.ts
@@ -1,0 +1,98 @@
+import {
+  isConnected,
+  requestAccess,
+  getNetwork,
+  signMessage as freighterSignMessage,
+  signTransaction as freighterSignTransaction,
+} from '@stellar/freighter-api';
+import {
+  WalletAdapterError,
+  type SignOptions,
+  type WalletAdapter,
+  type WalletAvailability,
+  type WalletConnection,
+} from './types';
+
+/** Freighter reports availability only after the extension injects itself. */
+const AVAILABILITY_ATTEMPTS = 5;
+const AVAILABILITY_DELAY_MS = 100;
+
+async function waitForExtension(): Promise<boolean> {
+  for (let attempt = 0; attempt < AVAILABILITY_ATTEMPTS; attempt++) {
+    try {
+      const { isConnected: available } = await isConnected();
+      if (available) return true;
+    } catch {
+      // Extension not injected yet — retry.
+    }
+    await new Promise((resolve) => setTimeout(resolve, AVAILABILITY_DELAY_MS));
+  }
+  return false;
+}
+
+export const freighterAdapter: WalletAdapter = {
+  id: 'freighter',
+  name: 'Freighter',
+  description: 'Browser extension by the Stellar Development Foundation',
+  isImplemented: true,
+
+  async isAvailable(): Promise<WalletAvailability> {
+    const available = await waitForExtension();
+    return available ? { isAvailable: true } : { isAvailable: false, reason: 'NOT_INSTALLED' };
+  },
+
+  async connect(): Promise<WalletConnection> {
+    const available = await waitForExtension();
+    if (!available) {
+      throw new WalletAdapterError(
+        'freighter',
+        'Freighter is not installed or not unlocked. Install Freighter and try again.',
+      );
+    }
+
+    const { address, error } = await requestAccess();
+    if (error) {
+      throw new WalletAdapterError('freighter', String(error));
+    }
+    if (!address) {
+      throw new WalletAdapterError('freighter', 'User denied access');
+    }
+
+    const { network } = await getNetwork();
+    return { address, network: (network as string | null) || null };
+  },
+
+  async signMessage(message: string, options: SignOptions): Promise<string> {
+    const { signedMessage, error } = await freighterSignMessage(message, {
+      address: options.address,
+      networkPassphrase: options.networkPassphrase,
+    });
+
+    if (error) {
+      throw new WalletAdapterError('freighter', error.message ?? 'Failed to sign message');
+    }
+    if (!signedMessage) {
+      throw new WalletAdapterError('freighter', 'Signing cancelled or rejected by user.');
+    }
+
+    return typeof signedMessage === 'string' ? signedMessage : String(signedMessage);
+  },
+
+  async signTransaction(xdr: string, options: SignOptions): Promise<string> {
+    const result = await freighterSignTransaction(xdr, {
+      networkPassphrase: options.networkPassphrase,
+    });
+
+    if (typeof result === 'string') return result;
+
+    if (result && typeof result === 'object') {
+      if ('error' in result && result.error) {
+        throw new WalletAdapterError('freighter', String(result.error));
+      }
+      const signed = (result as { signedTxXdr?: string }).signedTxXdr;
+      if (signed) return signed;
+    }
+
+    throw new WalletAdapterError('freighter', 'Signing cancelled or rejected by user.');
+  },
+};

--- a/src/lib/wallets/index.ts
+++ b/src/lib/wallets/index.ts
@@ -1,0 +1,21 @@
+import { freighterAdapter } from './freighter';
+import { albedoAdapter, lobstrAdapter } from './stubs';
+import type { WalletAdapter, WalletId } from './types';
+
+/**
+ * Registry of every wallet the picker offers, in display order.
+ *
+ * Adding a wallet: implement a `WalletAdapter` and append it here.
+ */
+export const WALLET_ADAPTERS: readonly WalletAdapter[] = [
+  freighterAdapter,
+  albedoAdapter,
+  lobstrAdapter,
+];
+
+export function getWalletAdapter(id: WalletId): WalletAdapter | undefined {
+  return WALLET_ADAPTERS.find((adapter) => adapter.id === id);
+}
+
+export { freighterAdapter, albedoAdapter, lobstrAdapter };
+export * from './types';

--- a/src/lib/wallets/stubs.ts
+++ b/src/lib/wallets/stubs.ts
@@ -1,0 +1,58 @@
+import {
+  WalletAdapterError,
+  type WalletAdapter,
+  type WalletAvailability,
+  type WalletConnection,
+} from './types';
+
+/**
+ * Placeholder adapters for wallets that are planned but not yet wired.
+ *
+ * They exist so the picker can advertise the roadmap and so adding real support
+ * is a matter of filling in these methods — the picker, store, and components
+ * need no changes.
+ */
+function notImplemented(
+  id: WalletAdapter['id'],
+  name: string,
+  description: string,
+): WalletAdapter {
+  const fail = (): never => {
+    throw new WalletAdapterError(id, `${name} support is not available yet.`);
+  };
+
+  return {
+    id,
+    name,
+    description,
+    isImplemented: false,
+
+    async isAvailable(): Promise<WalletAvailability> {
+      return { isAvailable: false, reason: 'NOT_IMPLEMENTED' };
+    },
+
+    async connect(): Promise<WalletConnection> {
+      return fail();
+    },
+
+    async signMessage(): Promise<string> {
+      return fail();
+    },
+
+    async signTransaction(): Promise<string> {
+      return fail();
+    },
+  };
+}
+
+export const albedoAdapter = notImplemented(
+  'albedo',
+  'Albedo',
+  'Web-based signer — no extension required',
+);
+
+export const lobstrAdapter = notImplemented(
+  'lobstr',
+  'LOBSTR',
+  'Mobile and browser wallet with WalletConnect',
+);

--- a/src/lib/wallets/types.ts
+++ b/src/lib/wallets/types.ts
@@ -1,0 +1,71 @@
+/**
+ * Wallet adapter contract.
+ *
+ * Every supported wallet is expressed as a `WalletAdapter`. The app talks only
+ * to this interface, so adding a wallet means adding one adapter file and one
+ * registry entry — no changes to the store or to any component.
+ */
+
+export type WalletId = 'freighter' | 'albedo' | 'lobstr';
+
+/** Why an adapter cannot currently be used. */
+export type WalletUnavailableReason =
+  | 'NOT_INSTALLED'
+  | 'NOT_IMPLEMENTED'
+  | 'UNSUPPORTED_PLATFORM';
+
+export interface WalletAvailability {
+  isAvailable: boolean;
+  reason?: WalletUnavailableReason;
+}
+
+export interface WalletConnection {
+  /** Connected G-address. */
+  address: string;
+  /** Network reported by the wallet, e.g. `TESTNET`. Null when unknown. */
+  network: string | null;
+}
+
+export interface SignOptions {
+  networkPassphrase: string;
+  address?: string;
+}
+
+export interface WalletAdapter {
+  readonly id: WalletId;
+  /** Display name shown in the picker. */
+  readonly name: string;
+  /** One-line description shown under the name. */
+  readonly description: string;
+  /**
+   * True once the adapter is fully wired. Adapters that exist only to reserve
+   * a slot in the picker report false and render as "Coming soon".
+   */
+  readonly isImplemented: boolean;
+
+  /**
+   * Whether this wallet can be used right now — typically an extension-presence
+   * check. Must not prompt the user.
+   */
+  isAvailable(): Promise<WalletAvailability>;
+
+  /** Requests access and returns the connected address and network. */
+  connect(): Promise<WalletConnection>;
+
+  /** Signs an arbitrary message, used for backend challenge/response auth. */
+  signMessage(message: string, options: SignOptions): Promise<string>;
+
+  /** Signs a transaction XDR and returns the signed XDR. */
+  signTransaction(xdr: string, options: SignOptions): Promise<string>;
+}
+
+/** Thrown when an adapter cannot complete a request. */
+export class WalletAdapterError extends Error {
+  readonly walletId: WalletId;
+
+  constructor(walletId: WalletId, message: string) {
+    super(message);
+    this.name = 'WalletAdapterError';
+    this.walletId = walletId;
+  }
+}

--- a/src/lib/wallets/wallets.test.ts
+++ b/src/lib/wallets/wallets.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { WALLET_ADAPTERS, getWalletAdapter, freighterAdapter } from './index';
+import { albedoAdapter, lobstrAdapter } from './stubs';
+import { WalletAdapterError } from './types';
+
+describe('wallet adapter registry', () => {
+  it('exposes Freighter first so it is the default choice', () => {
+    expect(WALLET_ADAPTERS[0].id).toBe('freighter');
+  });
+
+  it('has no duplicate wallet ids', () => {
+    const ids = WALLET_ADAPTERS.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('gives every adapter the full interface', () => {
+    for (const adapter of WALLET_ADAPTERS) {
+      expect(typeof adapter.name).toBe('string');
+      expect(typeof adapter.description).toBe('string');
+      expect(typeof adapter.isImplemented).toBe('boolean');
+      expect(typeof adapter.isAvailable).toBe('function');
+      expect(typeof adapter.connect).toBe('function');
+      expect(typeof adapter.signMessage).toBe('function');
+      expect(typeof adapter.signTransaction).toBe('function');
+    }
+  });
+
+  it('looks adapters up by id', () => {
+    expect(getWalletAdapter('freighter')).toBe(freighterAdapter);
+    expect(getWalletAdapter('albedo')).toBe(albedoAdapter);
+  });
+
+  it('marks only Freighter as implemented today', () => {
+    expect(freighterAdapter.isImplemented).toBe(true);
+    expect(albedoAdapter.isImplemented).toBe(false);
+    expect(lobstrAdapter.isImplemented).toBe(false);
+  });
+});
+
+describe('stub adapters', () => {
+  it.each([albedoAdapter, lobstrAdapter])('reports %s as unavailable', async (adapter) => {
+    await expect(adapter.isAvailable()).resolves.toEqual({
+      isAvailable: false,
+      reason: 'NOT_IMPLEMENTED',
+    });
+  });
+
+  it('throws a WalletAdapterError naming the wallet when connect is attempted', async () => {
+    await expect(albedoAdapter.connect()).rejects.toBeInstanceOf(WalletAdapterError);
+    await expect(albedoAdapter.connect()).rejects.toThrow(/albedo support is not available yet/i);
+  });
+
+  it('throws on signing attempts', async () => {
+    const options = { networkPassphrase: 'Test SDF Network ; September 2015' };
+    await expect(lobstrAdapter.signMessage('msg', options)).rejects.toBeInstanceOf(
+      WalletAdapterError,
+    );
+    await expect(lobstrAdapter.signTransaction('xdr', options)).rejects.toBeInstanceOf(
+      WalletAdapterError,
+    );
+  });
+
+  it('tags the error with the wallet id', async () => {
+    await albedoAdapter.connect().catch((err) => {
+      expect(err).toBeInstanceOf(WalletAdapterError);
+      expect((err as WalletAdapterError).walletId).toBe('albedo');
+    });
+  });
+});

--- a/src/lib/xelma-contract.ts
+++ b/src/lib/xelma-contract.ts
@@ -26,6 +26,15 @@ export interface FeeEstimate {
   readBytes: string;
   /** Ledger write bytes. */
   writeBytes: string;
+  /**
+   * Base64 XDR of the prepared (unsigned) transaction — the exact payload that
+   * will be handed to Freighter for approval.
+   */
+  xdr: string;
+  /** Hash of the prepared transaction, before signing. */
+  hash: string;
+  /** Network passphrase the transaction is built against. */
+  networkPassphrase: string;
 }
 
 const STROOPS_PER_XLM = 10_000_000;
@@ -204,7 +213,7 @@ async function simulateContractCall(
   }
 
   // Prepare applies the simulation footprint & resource fee to the tx
-  await rpcServer.prepareTransaction(tx);
+  const preparedTx = await rpcServer.prepareTransaction(tx);
 
   const baseFeeStroops = Number(BASE_FEE) || 100;
   const resourceFeeStroops = simulation.minResourceFee ? Number(simulation.minResourceFee) : 0;
@@ -216,6 +225,9 @@ async function simulateContractCall(
     instructions: simulation.cost?.cpuInsns ? String(simulation.cost.cpuInsns) : '0',
     readBytes: simulation.cost?.readBytes ? String(simulation.cost.readBytes) : '0',
     writeBytes: simulation.cost?.writeBytes ? String(simulation.cost.writeBytes) : '0',
+    xdr: preparedTx.toXDR(),
+    hash: preparedTx.hash().toString('hex'),
+    networkPassphrase: NETWORK_PASSPHRASE,
   };
 }
 

--- a/src/lib/xelma-contract.ts
+++ b/src/lib/xelma-contract.ts
@@ -1,5 +1,5 @@
 import { rpc, Contract, TransactionBuilder, BASE_FEE, Networks, Address, nativeToScVal, xdr } from '@stellar/stellar-sdk';
-import { signTransaction } from '@stellar/freighter-api';
+import { freighterAdapter } from './wallets';
 
 const RPC_URL = import.meta.env.VITE_STELLAR_RPC_URL || 'https://soroban-testnet.stellar.org';
 const XELMA_CONTRACT_ID = import.meta.env.VITE_XELMA_CONTRACT_ID || 'CD7V3L7JIP52EXWLYSOWXND4F3N65QZ2R54H6M77Y3S37Z55XHLXELMA';
@@ -128,30 +128,18 @@ async function executeContractCall(
     throw new Error('Failed to assemble transaction layout with simulated resources.');
   }
 
-  // 5. Sign with Freighter wallet
-  let signedResult;
+  // 5. Sign with the connected wallet
+  let signedXdrString: string;
   try {
     onStatus?.('signing');
-    signedResult = await signTransaction(preparedTx.toXDR(), {
+    signedXdrString = await freighterAdapter.signTransaction(preparedTx.toXDR(), {
       networkPassphrase: NETWORK_PASSPHRASE,
     });
   } catch (err) {
-    console.error('Freighter sign transaction error:', err);
-    throw new Error('Failed to sign transaction with Freighter wallet.');
-  }
-
-  let signedXdrString: string | null = null;
-  if (typeof signedResult === 'string') {
-    signedXdrString = signedResult;
-  } else if (signedResult && typeof signedResult === 'object') {
-    if ('error' in signedResult && signedResult.error) {
-      throw new Error(`Freighter signing rejected: ${signedResult.error}`);
-    }
-    signedXdrString = (signedResult as { signedTxXdr?: string }).signedTxXdr || null;
-  }
-
-  if (!signedXdrString) {
-    throw new Error('Signing cancelled or rejected by user.');
+    console.error('Wallet sign transaction error:', err);
+    throw new Error(
+      err instanceof Error ? err.message : 'Failed to sign transaction with your wallet.',
+    );
   }
 
   // 6. Submit the signed transaction to RPC

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -5,6 +5,7 @@ import { Loader2, CheckCircle2, XCircle, Wallet, AlertCircle, ChevronDown, Chevr
 import clsx from 'clsx';
 import { toast } from 'sonner';
 import WalletConnect from '../components/WalletConnect';
+import BalancesPanel from '../components/BalancesPanel';
 import { useWalletStore } from '../store/useWalletStore';
 import { useNavigate } from 'react-router-dom';
 
@@ -125,13 +126,16 @@ const Connect = () => {
           <div className="mb-6">
             <WalletConnect />
             {isConnected && (
-              <button
-                type="button"
-                onClick={() => navigate('/dashboard')}
-                className="btn-primary mt-4 w-full rounded-xl px-4 py-3 text-sm font-bold"
-              >
-                Continue to Dashboard
-              </button>
+              <>
+                <BalancesPanel className="mt-4" />
+                <button
+                  type="button"
+                  onClick={() => navigate('/dashboard')}
+                  className="btn-primary mt-4 w-full rounded-xl px-4 py-3 text-sm font-bold"
+                >
+                  Continue to Dashboard
+                </button>
+              </>
             )}
           </div>
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -14,6 +14,8 @@ import type { PredictionData } from "../components/PredictionControls";
 import BetModal from "../components/BetModal";
 import EndRoundModal from "../components/EndRoundModal";
 import RoundTimeline from "../components/RoundTimeline";
+import EventLogDrawer from "../components/EventLogDrawer";
+import { Radio } from "lucide-react";
 import { ChatSidebar } from "../components/ChatSidebar";
 import { ConnectionStatus } from "../components/ConnectionStatus";
 import { useConnectionStatus } from "../hooks/useConnectionStatus";
@@ -152,6 +154,7 @@ const Dashboard = () => {
   const [pendingPrediction, setPendingPrediction] = useState<PredictionData | null>(null);
   // Community chat is opt-in so the default terminal stays uncluttered.
   const [isChatOpen, setIsChatOpen] = useState(false);
+  const [isEventLogOpen, setIsEventLogOpen] = useState(false);
   const timeoutRef = useRef<number | null>(null);
 
   const [stats, setStats] = useState<UserStats | null>(null);
@@ -330,6 +333,16 @@ const Dashboard = () => {
         {/* Round lifecycle timeline, ported from /play. */}
         {!isLoading && (
           <div className="mb-6">
+            <div className="mb-3 flex justify-end">
+              <button
+                type="button"
+                onClick={() => setIsEventLogOpen(true)}
+                className="inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-gray-400 transition-colors hover:border-[#2C4BFD]/40 hover:text-white"
+              >
+                <Radio className="h-4 w-4" aria-hidden />
+                On-chain events
+              </button>
+            </div>
             <RoundTimeline />
           </div>
         )}
@@ -468,6 +481,7 @@ const Dashboard = () => {
         onClose={dismissResolvedRound}
         result={endRoundResult}
       />
+      <EventLogDrawer isOpen={isEventLogOpen} onClose={() => setIsEventLogOpen(false)} />
     </div>
   );
 };

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 import ProfileSettingsModal from '../components/ProfileSettingsModal';
 import IdenticonAvatar from '../components/IdenticonAvatar';
+import BalancesPanel from '../components/BalancesPanel';
 import { useProfileStore } from '../store/useProfileStore';
 import { useWalletStore } from '../store/useWalletStore';
 import type { ProfileSettingsValues } from '../lib/profileApi';
@@ -223,6 +224,8 @@ export default function Profile() {
               </section>
 
               <aside className="space-y-6" aria-label="Profile details">
+                <BalancesPanel />
+
                 <section className="glass-card rounded-xl p-5">
                   <div className="flex items-center gap-3">
                     <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#2C4BFD]/15 text-[#BEC7FE]">

--- a/src/store/useWalletStore.ts
+++ b/src/store/useWalletStore.ts
@@ -9,6 +9,7 @@ import {
 import { toast } from 'sonner';
 import { useAuthStore } from './useAuthStore';
 import { getApiBaseUrl } from '../lib/apiConfig';
+import { HORIZON_URL } from '../lib/horizon';
 
 const API_BASE = getApiBaseUrl();
 
@@ -138,7 +139,7 @@ export const useWalletStore = create<WalletState>((set, get) => ({
 
         let formattedBalance: string | null = null;
         try {
-          const response = await fetch(`https://horizon-testnet.stellar.org/accounts/${address}`);
+          const response = await fetch(`${HORIZON_URL}/accounts/${address}`);
           if (response.status === 404) {
             formattedBalance = '0.00 XLM';
           } else if (!response.ok) {
@@ -236,7 +237,7 @@ export const useWalletStore = create<WalletState>((set, get) => ({
 
       let formattedBalance: string | null = null;
       try {
-        const response = await fetch(`https://horizon-testnet.stellar.org/accounts/${address}`);
+        const response = await fetch(`${HORIZON_URL}/accounts/${address}`);
         if (response.status === 404) {
           formattedBalance = '0.00 XLM';
         } else if (!response.ok) {

--- a/src/store/useWalletStore.ts
+++ b/src/store/useWalletStore.ts
@@ -1,12 +1,7 @@
 import { create } from 'zustand';
-import {
-  isConnected,
-  requestAccess,
-  getAddress,
-  getNetwork,
-  signMessage,
-} from '@stellar/freighter-api';
+import { isConnected, getAddress, getNetwork } from '@stellar/freighter-api';
 import { toast } from 'sonner';
+import { freighterAdapter } from '../lib/wallets';
 import { useAuthStore } from './useAuthStore';
 import { getApiBaseUrl } from '../lib/apiConfig';
 import { HORIZON_URL } from '../lib/horizon';
@@ -197,17 +192,8 @@ export const useWalletStore = create<WalletState>((set, get) => ({
     });
 
     try {
-      let connected = false;
-      for (let i = 0; i < 5; i++) {
-        const { isConnected: isFreighterConnected } = await isConnected();
-        if (isFreighterConnected) {
-          connected = true;
-          break;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
-
-      if (!connected) {
+      const { isAvailable } = await freighterAdapter.isAvailable();
+      if (!isAvailable) {
         set({
           status: 'error',
           errorMessage: 'Freighter is not installed or not unlocked. Install Freighter and try again.',
@@ -221,18 +207,12 @@ export const useWalletStore = create<WalletState>((set, get) => ({
         setTimeout(() => reject(new Error('TIMEOUT')), 30000);
       });
 
-      const accessResult = await Promise.race([requestAccess(), timeoutPromise]);
-      const { address, error } = accessResult;
+      const { address, network } = await Promise.race([
+        freighterAdapter.connect(),
+        timeoutPromise,
+      ]);
 
-      if (error) {
-        throw new Error(String(error));
-      }
-      if (!address) {
-        throw new Error('User denied access');
-      }
-
-      const { network } = await getNetwork();
-      const net = (network as string | null) || null;
+      const net = network;
       const networkMismatch = net !== 'TESTNET';
 
       let formattedBalance: string | null = null;
@@ -282,15 +262,13 @@ export const useWalletStore = create<WalletState>((set, get) => ({
 
         const { challenge } = await challengeRes.json();
 
-        const { signedMessage, error: signError } = await signMessage(challenge, {
+        const signedMessage = await freighterAdapter.signMessage(challenge, {
           address,
           networkPassphrase:
-            network === 'TESTNET'
+            net === 'TESTNET'
               ? 'Test SDF Network ; September 2015'
               : 'Public Global Stellar Network ; September 2015',
         });
-
-        if (signError) throw new Error(signError.message ?? 'Failed to sign challenge');
 
         const connectRes = await fetch(`${API_BASE}/api/auth/connect`, {
           method: 'POST',


### PR DESCRIPTION
Implements four related wallet and on-chain visibility features. Each is a separate commit so they can be reviewed independently.

Closes #300
Closes #298
Closes #299
Closes #304

---

## #300 — Horizon balances and trustlines mini-viewer

New `BalancesPanel` showing the native XLM balance plus every trustline on the connected account, mounted in the Connect panel and the Profile sidebar.

- **Network-aware Horizon URL from env** — new `src/lib/horizon.ts` resolves the endpoint from `VITE_STELLAR_HORIZON_URL`, falling back to a value derived from `VITE_STELLAR_NETWORK`. This replaces **two hardcoded `horizon-testnet.stellar.org` URLs** in `useWalletStore`, so one network switch now moves the whole app between testnet and mainnet.
- **Loading / error / empty states** — plus a distinct unfunded-account state: a Horizon 404 is an expected result for an unfunded G-address, so it renders as empty rather than an error.
- Balances are keyed to the address they were fetched for, so switching wallets never briefly shows the previous account's numbers.

## #298 — XDR preview drawer before Freighter approval

New `XdrPreviewDrawer` on the prediction submit path, showing the prepared transaction's XDR, hash, and network passphrase with a copy button.

- **Collapsed by default** — the casual prediction flow is untouched; only users who expand it see the payload.
- **No extra RPC cost.** The pre-approval simulation already built and prepared the transaction and then discarded it. Capturing it means the preview shows the *exact* payload Freighter will be handed, with no additional round-trip.
- Clipboard failures fall back to a "select and copy manually" message rather than silently doing nothing.

## #299 — Multi-wallet picker (Freighter first, Albedo-ready)

Landing copy advertised Albedo while only Freighter was wired. New `WalletPicker` lists every supported wallet; Freighter works end-to-end, Albedo and LOBSTR render disabled as "Coming soon".

### Adapter interface

`src/lib/wallets/types.ts` defines the contract the app talks to instead of calling `@stellar/freighter-api` directly:

```ts
interface WalletAdapter {
  readonly id: WalletId;
  readonly name: string;
  readonly description: string;
  readonly isImplemented: boolean;

  isAvailable(): Promise<WalletAvailability>;   // extension presence; must not prompt
  connect(): Promise<WalletConnection>;         // { address, network }
  signMessage(message, options): Promise<string>;     // backend challenge auth
  signTransaction(xdr, options): Promise<string>;     // returns signed XDR
}
```

**Adding a wallet** is one adapter file plus one entry in `WALLET_ADAPTERS` (`src/lib/wallets/index.ts`) — no store or component changes.

Two design points worth reviewing:

- `isAvailable()` is **separate from** `isImplemented`, so the picker can distinguish "not installed" (install Freighter) from "not built yet" (Coming soon). Conflating them would have made the roadmap rows indistinguishable from a broken extension.
- The abstraction is **load-bearing, not a parallel unused layer** — the store's connect flow *and* the contract signing path both route through the Freighter adapter. This removed the duplicated string-vs-object result unwrapping that previously existed in `xelma-contract.ts`.

Wired into `WalletConnect` (Connect page) and both Navbar connect buttons (desktop + mobile drawer).

## #304 — On-chain event log viewer for settlements

New `EventLogDrawer` on the Dashboard listing recent prediction and settlement events from Soroban RPC `getEvents`, scanned back over the RPC retention window from the latest ledger.

- **Filter by round id.** Round ids are read from either the event topics or a `round_id`/`roundId` payload field, since contracts differ in where they put them.
- Events are classified `settlement` / `prediction` / `round` so settlements are scannable at a glance.
- **Empty + loading states** — two distinct empty states: no events at all, vs none matching the active round filter (the latter offers a "clear filter" action).
- **Links out to the explorer when a tx hash is present**, via a shared network-aware helper. This also fixed the existing success-view link in `BetModal`, which pointed at `stellarexpert.org/tx/...` — wrong domain, and no network segment, so testnet hashes resolved against mainnet.

---

## Testing

**49 new tests added, all passing.** Covers Horizon fetching/formatting, the balances panel's four states, the XDR drawer's collapsed default and both clipboard paths, the adapter registry and stub adapters, event decoding and round filtering, and the event log's states/filter/links.

Two **existing** tests were updated because this branch deliberately changes the behaviour they asserted — flagging these explicitly for review:

1. `WalletConnect > calls connect when connect button is clicked` — the button now opens the picker instead of connecting immediately. Split into two tests: one asserting the picker opens and `connect` is *not* called, one asserting `connect` fires after Freighter is chosen.
2. `xelma-contract > throws error when user rejects Freighter signature` — the adapter now surfaces the wallet's own rejection message instead of a generic `"Freighter signing rejected"` string.

### A note on the repo's current CI state

`main` is **already red before this branch**, and `npm ci` fails on a pre-existing peer conflict: `vite-plugin-pwa@0.18.2` peers `vite ^3 || ^4 || ^5`, but the repo runs `vite@7.3.1`. The last several CI runs on `main` fail at the install step.

I left that alone — it is outside the scope of these four issues and fixing it means a dependency bump that deserves its own PR. To keep this reviewable, I measured against a recorded baseline of untouched `main` instead:

| Check | `main` baseline | This branch |
| --- | --- | --- |
| `tsc -b` errors | 20 | **20** (unchanged) |
| `eslint .` | 7 errors, 2 warnings | **7 errors, 2 warnings** (unchanged) |
| Unit tests failing | 41 (8 files) | **41 (8 files)** (unchanged) |
| Unit tests passing | 450 | **510** |
| Newly failing files | — | **none** |

Every pre-existing failure is untouched, this branch adds none, and all new files are clean under both `tsc` and `eslint`. No `package.json` or lockfile changes are included.
